### PR TITLE
Organization as checkbox is cluttering the display

### DIFF
--- a/classes/Gems/Default/FieldReportAction.php
+++ b/classes/Gems/Default/FieldReportAction.php
@@ -123,7 +123,7 @@ class Gems_Default_FieldReportAction extends \Gems_Controller_ModelSnippetAction
 
         $orgs         = $this->currentUser->getRespondentOrgFilter();
         if (isset($filter['gr2t_id_organization'])) {
-            $orgs = array_intersect($orgs, $filter['gr2t_id_organization']);
+            $orgs = array_intersect($orgs, (array) $filter['gr2t_id_organization']);
         }
         $this->orgWhere = " AND gr2t_id_organization IN (" . implode(", ", $orgs) . ")";
 

--- a/classes/Gems/Snippets/AutosearchFormSnippet.php
+++ b/classes/Gems/Snippets/AutosearchFormSnippet.php
@@ -68,6 +68,13 @@ class Gems_Snippets_AutosearchFormSnippet extends \MUtil_Snippets_SnippetAbstrac
      * @var \MUtil_Model_ModelAbstract
      */
     protected $model;
+    
+    /**
+     * Should the organization element be displayed as a multicheckbox or not?
+     *
+     * @var boolean
+     */
+    protected $orgIsMultiCheckbox = true;
 
     /**
      *

--- a/classes/Gems/Snippets/Tracker/Compliance/ComplianceSearchFormSnippet.php
+++ b/classes/Gems/Snippets/Tracker/Compliance/ComplianceSearchFormSnippet.php
@@ -53,7 +53,15 @@ class Gems_Snippets_Tracker_Compliance_ComplianceSearchFormSnippet extends \Gems
                 );
 
         if (count($orgs) > 1) {
-            $elements[] = $this->_createMultiCheckBoxElements('gr2t_id_organization', $orgs);
+            if ($this->orgIsMultiCheckbox) {
+                $elements[] = $this->_createMultiCheckBoxElements('gr2t_id_organization', $orgs);
+            } else {
+                $elements[] = $this->_createSelectElement(
+                        'gr2t_id_organization',
+                        $orgs,
+                        $this->_('(all organizations)')
+                        );
+            }
         }
 
         $elements[] = null;

--- a/classes/Gems/Snippets/Tracker/Fields/FieldReportSearchSnippet.php
+++ b/classes/Gems/Snippets/Tracker/Fields/FieldReportSearchSnippet.php
@@ -47,7 +47,15 @@ class Gems_Snippets_Tracker_Fields_FieldReportSearchSnippet extends \Gems_Snippe
                 );
 
         if (count($orgs) > 1) {
-            $elements[] = $this->_createMultiCheckBoxElements('gr2t_id_organization', $orgs);
+            if ($this->orgIsMultiCheckbox) {
+                $elements[] = $this->_createMultiCheckBoxElements('gr2t_id_organization', $orgs);
+            } else {
+                $elements[] = $this->_createSelectElement(
+                        'gr2t_id_organization',
+                        $orgs,
+                        $this->_('(all organizations)')
+                        );
+            }
         }
 
         return $elements;

--- a/classes/Gems/Snippets/Tracker/Summary/SummarySearchFormSnippet.php
+++ b/classes/Gems/Snippets/Tracker/Summary/SummarySearchFormSnippet.php
@@ -47,7 +47,15 @@ class Gems_Snippets_Tracker_Summary_SummarySearchFormSnippet extends \Gems_Snipp
         $elements['gto_id_track']->setAttrib('onchange', 'this.form.submit();');
 
         if (count($orgs) > 1) {
-            $elements[] = $this->_createMultiCheckBoxElements('gto_id_organization', $orgs, ' ');
+            if ($this->orgIsMultiCheckbox) {
+                $elements[] = $this->_createMultiCheckBoxElements('gto_id_organization', $orgs, ' ');
+            } else {
+                $elements[] = $this->_createSelectElement(
+                        'gto_id_organization',
+                        $orgs,
+                        $this->_('(all organizations)')
+                        );
+            }
         }
 
         $elements[] = null;


### PR DESCRIPTION
Some of the overview screens have changed to show organization as a multi checkbox instead of the old dropdown. This is cluttering the display when there are more then a few organizations.

This allows to revert the change by using a switch at project level code.