### PR TITLE
Cache

### DIFF
--- a/classes/Gems/Cache/Backend.php
+++ b/classes/Gems/Cache/Backend.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Gems\Cache;
+
+/**
+ * Fix for 7.2 deprecation of each
+ */
+
+class Backend extends \Zend_Cache_Backend
+{
+    /**
+     * Set the frontend directives
+     * Version without using each for 7.2+
+     *
+     * @param  array $directives Assoc of directives
+     * @throws \Zend_Cache_Exception
+     * @return void
+     */
+    public function setDirectives($directives)
+    {
+
+        if (!is_array($directives)) \Zend_Cache::throwException('Directives parameter must be an array');
+
+        foreach ($directives as $name => $value) {
+            //while (list($name, $value) = each($directives)) {
+            if (!is_string($name)) {
+                Zend_Cache::throwException("Incorrect option name : $name");
+            }
+            $name = strtolower($name);
+            if (array_key_exists($name, $this->_directives)) {
+                $this->_directives[$name] = $value;
+            }
+        }
+
+        $this->_loggerSanity();
+    }
+}

--- a/classes/Gems/Cache/Backend/Apc.php
+++ b/classes/Gems/Cache/Backend/Apc.php
@@ -78,5 +78,32 @@ class Apc extends \Zend_Cache_Backend_Apc
         $iterator = new \APCIterator('user', "/^$prefix/", APC_ITER_KEY);
         return apc_delete($iterator);
     }
+
+    /**
+     * Set the frontend directives
+     * Version without using each for 7.2+
+     *
+     * @param  array $directives Assoc of directives
+     * @throws \Zend_Cache_Exception
+     * @return void
+     */
+    public function setDirectives($directives)
+    {
+
+        if (!is_array($directives)) \Zend_Cache::throwException('Directives parameter must be an array');
+
+        foreach ($directives as $name => $value) {
+            //while (list($name, $value) = each($directives)) {
+            if (!is_string($name)) {
+                Zend_Cache::throwException("Incorrect option name : $name");
+            }
+            $name = strtolower($name);
+            if (array_key_exists($name, $this->_directives)) {
+                $this->_directives[$name] = $value;
+            }
+        }
+
+        $this->_loggerSanity();
+    }
     
 }

--- a/classes/Gems/Cache/Backend/File.php
+++ b/classes/Gems/Cache/Backend/File.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Gems\Cache\Backend;
+
+
+class File extends \Zend_Cache_Backend_File
+{
+    /**
+     * Set the frontend directives
+     * Version without using each for 7.2+
+     *
+     * @param  array $directives Assoc of directives
+     * @throws \Zend_Cache_Exception
+     * @return void
+     */
+    public function setDirectives($directives)
+    {
+
+        if (!is_array($directives)) \Zend_Cache::throwException('Directives parameter must be an array');
+        
+        foreach($directives as $name=>$value) {
+        //while (list($name, $value) = each($directives)) {
+            if (!is_string($name)) {
+                Zend_Cache::throwException("Incorrect option name : $name");
+            }
+            $name = strtolower($name);
+            if (array_key_exists($name, $this->_directives)) {
+                $this->_directives[$name] = $value;
+            }
+        }
+
+        $this->_loggerSanity();
+    }
+}
+

--- a/classes/Gems/Cache/Backend/Psr16Cache.php
+++ b/classes/Gems/Cache/Backend/Psr16Cache.php
@@ -1,0 +1,133 @@
+<?php
+
+/**
+ * A Zend Cache 1 backend wrapper for PSR-16 compatible Cache libraries like Symfony cache 3.4+
+ */
+
+namespace Gems\Cache\Backend;
+
+
+use Psr\SimpleCache\CacheInterface;
+use Gems\Cache\Backend;
+
+class Psr16Cache extends Backend implements \Zend_Cache_Backend_Interface
+{
+    /**
+     * @var CacheInterface PSR-16 cache interface
+     */
+    protected $cache;
+
+    public function __construct(CacheInterface $cache)
+    {
+        $this->cache = $cache;
+    }
+
+    /**
+     * Get the cache storage adapter
+     *
+     * @return CacheInterface
+     */
+    public function getCache()
+    {
+        return $this->cache;
+    }
+
+    /**
+     * Test if a cache is available for the given id and (if yes) return it (false else)
+     *
+     * Note : return value is always "string" (unserialization is done by the core not by the backend)
+     *
+     * @param  string  $id                     Cache id
+     * @param  boolean $doNotTestCacheValidity If set to true, the cache validity won't be tested
+     * @return string|false cached datas
+     */
+    public function load($id, $doNotTestCacheValidity = false)
+    {
+        return $this->cache->get($id, false);
+    }
+
+    /**
+     * Test if a cache is available or not (for the given id)
+     *
+     * @param  string $id cache id
+     * @return mixed|false (a cache is not available) or "last modified" timestamp (int) of the available cache record
+     */
+    public function test($id)
+    {
+        return $this->cache->has($id);
+    }
+
+    /**
+     * Save some string datas into a cache record
+     *
+     * Note : $data is always "string" (serialization is done by the
+     * core not by the backend)
+     *
+     * @param  string $data            Datas to cache
+     * @param  string $id              Cache id
+     * @param  array $tags             Array of strings, the cache record will be tagged by each string entry
+     * @param  int   $specificLifetime If != false, set a specific lifetime for this cache record (null => infinite lifetime)
+     * @return boolean true if no problem
+     */
+    public function save($data, $id, $tags = array(), $specificLifetime = false)
+    {
+        if (!empty($tags)) {
+            $this->_log('Tags are not supported in psr-16 backends');
+        }
+        if ($specificLifetime === false) {
+            $specificLifetime = null;
+        }
+
+        return $this->cache->set($id, $data, $specificLifetime);
+    }
+
+    /**
+     * Remove a cache record
+     *
+     * @param  string $id Cache id
+     * @return boolean True if no problem
+     */
+    public function remove($id)
+    {
+        $this->cache->delete($id);
+    }
+
+    /**
+     * Clean some cache records
+     *
+     * Available modes are :
+     * Zend_Cache::CLEANING_MODE_ALL (default)    => remove all cache entries ($tags is not used)
+     * Zend_Cache::CLEANING_MODE_OLD              => remove too old cache entries ($tags is not used)
+     * Zend_Cache::CLEANING_MODE_MATCHING_TAG     => remove cache entries matching all given tags
+     *                                               ($tags can be an array of strings or a single string)
+     * Zend_Cache::CLEANING_MODE_NOT_MATCHING_TAG => remove cache entries not {matching one of the given tags}
+     *                                               ($tags can be an array of strings or a single string)
+     * Zend_Cache::CLEANING_MODE_MATCHING_ANY_TAG => remove cache entries matching any given tags
+     *                                               ($tags can be an array of strings or a single string)
+     *
+     * @param  string $mode Clean mode
+     * @param  array  $tags Array of tags
+     * @return boolean true if no problem
+     */
+    public function clean($mode = \Zend_Cache::CLEANING_MODE_ALL, $tags = array())
+    {
+        \MUtil_Echo::track($mode);
+        switch ($mode) {
+            case \Zend_Cache::CLEANING_MODE_ALL:
+                $this->cache->clear();
+                return true;
+                break;
+            case \Zend_Cache::CLEANING_MODE_OLD:
+                throw new \Exception("CLEANING_MODE_OLD is unsupported by the PSR-16 backends.");
+                break;
+            case \Zend_Cache::CLEANING_MODE_MATCHING_TAG:
+            case \Zend_Cache::CLEANING_MODE_NOT_MATCHING_TAG:
+            case \Zend_Cache::CLEANING_MODE_MATCHING_ANY_TAG:
+                throw new \Exception('Tags are unsupported by the PSR-16 backends.');
+                break;
+            default:
+                \Zend_Cache::throwException('Invalid mode for clean() method');
+                break;
+        }
+    }
+}

--- a/classes/Gems/Cache/Backend/Psr6Cache.php
+++ b/classes/Gems/Cache/Backend/Psr6Cache.php
@@ -1,0 +1,283 @@
+<?php
+
+/**
+ * A Zend Cache 1 backend wrapper for PSR-6 compatible Cache libraries like Symfony cache 3.3+
+ */
+
+namespace Gems\Cache\Backend;
+
+use Gems\Cache\Backend;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
+
+class Psr6Cache extends Backend implements \Zend_Cache_Backend_ExtendedInterface
+{
+    protected $cache;
+
+    public function __construct(CacheItemPoolInterface $cache)
+    {
+        $this->cache = $cache;
+    }
+
+    /**
+     * Get the cache storage adapter
+     *
+     * @return CacheInterface
+     */
+    public function getCache()
+    {
+        return $this->cache;
+    }
+
+    /**
+     * Test if a cache is available for the given id and (if yes) return it (false else)
+     *
+     * Note : return value is always "string" (unserialization is done by the core not by the backend)
+     *
+     * @param  string  $id                     Cache id
+     * @param  boolean $doNotTestCacheValidity If set to true, the cache validity won't be tested
+     * @return string|false cached datas
+     */
+    public function load($id, $doNotTestCacheValidity = false)
+    {
+        $item = $this->cache->getItem($id);
+        return $item->get();
+    }
+
+    /**
+     * Test if a cache is available or not (for the given id)
+     *
+     * @param  string $id cache id
+     * @return mixed|false (a cache is not available) or "last modified" timestamp (int) of the available cache record
+     */
+    public function test($id)
+    {
+        $this->cache->hasItem($id);
+    }
+
+    /**
+     * Save some string datas into a cache record
+     *
+     * Note : $data is always "string" (serialization is done by the
+     * core not by the backend)
+     *
+     * @param  string $data            Datas to cache
+     * @param  string $id              Cache id
+     * @param  array $tags             Array of strings, the cache record will be tagged by each string entry
+     * @param  int   $specificLifetime If != false, set a specific lifetime for this cache record (null => infinite lifetime)
+     * @return boolean true if no problem
+     */
+    public function save($data, $id, $tags = array(), $specificLifetime = false)
+    {
+        $item = $this->cache->getItem($id);
+        $item->set($data);
+        if ($specificLifetime !== false) {
+            $item->expiresAfter($specificLifetime);
+        }
+
+        if ($this->isTagAware()) {
+            $item->tag($tags);
+        } else {
+            $this->_log('Tag support is not enabled in this PSR-6 backend');
+        }
+
+        return $this->cache->save($item);
+    }
+
+    /**
+     * Remove a cache record
+     *
+     * @param  string $id Cache id
+     * @return boolean True if no problem
+     */
+    public function remove($id)
+    {
+        $this->cache->deleteItem($id);
+    }
+
+    /**
+     * Clean some cache records
+     *
+     * Available modes are :
+     * Zend_Cache::CLEANING_MODE_ALL (default)    => remove all cache entries ($tags is not used)
+     * Zend_Cache::CLEANING_MODE_OLD              => remove too old cache entries ($tags is not used)
+     * Zend_Cache::CLEANING_MODE_MATCHING_TAG     => remove cache entries matching all given tags
+     *                                               ($tags can be an array of strings or a single string)
+     * Zend_Cache::CLEANING_MODE_NOT_MATCHING_TAG => remove cache entries not {matching one of the given tags}
+     *                                               ($tags can be an array of strings or a single string)
+     * Zend_Cache::CLEANING_MODE_MATCHING_ANY_TAG => remove cache entries matching any given tags
+     *                                               ($tags can be an array of strings or a single string)
+     *
+     * @param  string $mode Clean mode
+     * @param  array  $tags Array of tags
+     * @return boolean true if no problem
+     */
+    public function clean($mode = \Zend_Cache::CLEANING_MODE_ALL, $tags = array())
+    {
+        switch ($mode) {
+            case \Zend_Cache::CLEANING_MODE_ALL:
+                $this->cache->clear();
+                return true;
+                break;
+            case \Zend_Cache::CLEANING_MODE_OLD:
+                throw new \Exception("CLEANING_MODE_OLD is unsupported by the PSR-6 backends.");
+                break;
+            case \Zend_Cache::CLEANING_MODE_MATCHING_TAG:
+            case \Zend_Cache::CLEANING_MODE_NOT_MATCHING_TAG:
+            case \Zend_Cache::CLEANING_MODE_MATCHING_ANY_TAG:
+
+                if (!$this->isTagAware()) {
+                    throw new \Exception("Tags are unsupported by this PSR-6 backend.");
+                }
+
+                $this->cache->invalidateTags($tags);
+                break;
+            default:
+                \Zend_Cache::throwException('Invalid mode for clean() method');
+                break;
+        }
+    }
+
+    /**
+     * Return an array of stored cache ids
+     *
+     * @return array array of stored cache ids (string)
+     */
+    public function getIds()
+    {
+        throw new \Exception('Get list of set ids is not supported in PSR-6 backends');
+    }
+
+    /**
+     * Return an array of stored tags
+     *
+     * @return array array of stored tags (string)
+     */
+    public function getTags()
+    {
+        throw new \Exception('Get list of set tags is not supported in PSR-6 backends');
+    }
+
+    /**
+     * Return an array of stored cache ids which match given tags
+     *
+     * In case of multiple tags, a logical AND is made between tags
+     *
+     * @param array $tags array of tags
+     * @return array array of matching cache ids (string)
+     */
+    public function getIdsMatchingTags($tags = array())
+    {
+        throw new \Exception('Get list of set Ids matching a tag is not supported in PSR-6 backends');
+    }
+
+    /**
+     * Return an array of stored cache ids which don't match given tags
+     *
+     * In case of multiple tags, a logical OR is made between tags
+     *
+     * @param array $tags array of tags
+     * @return array array of not matching cache ids (string)
+     */
+    public function getIdsNotMatchingTags($tags = array())
+    {
+        throw new \Exception('Get list of set Ids not matching a tag is not supported in PSR-6 backends');
+    }
+
+    /**
+     * Return an array of stored cache ids which match any given tags
+     *
+     * In case of multiple tags, a logical AND is made between tags
+     *
+     * @param array $tags array of tags
+     * @return array array of any matching cache ids (string)
+     */
+    public function getIdsMatchingAnyTags($tags = array())
+    {
+        throw new \Exception('Get list of set Ids matching any tag is not supported in PSR-6 backends');
+    }
+
+    /**
+     * Return the filling percentage of the backend storage
+     *
+     * @return int integer between 0 and 100
+     */
+    public function getFillingPercentage()
+    {
+        throw new \Exception('Get filling percentage is not supported in PSR-6 backends');
+    }
+
+    /**
+     * Return an array of metadatas for the given cache id
+     *
+     * The array must include these keys :
+     * - expire : the expire timestamp
+     * - tags : a string array of tags
+     * - mtime : timestamp of last modification time
+     *
+     * @param string $id cache id
+     * @return array array of metadatas (false if the cache id is not found)
+     */
+    public function getMetadatas($id)
+    {
+        throw new \Exception('Get metadatas is not supported in PSR-6 backends');
+    }
+
+    /**
+     * Give (if possible) an extra lifetime to the given cache id
+     *
+     * @param string $id cache id
+     * @param int $extraLifetime
+     * @return boolean true if ok
+     */
+    public function touch($id, $extraLifetime)
+    {
+        $item = $this->cache->getItem($id);
+        $item->expiresAfter($extraLifetime);
+        $this->cache->save($item);
+    }
+
+    /**
+     * Return an associative array of capabilities (booleans) of the backend
+     *
+     * The array must include these keys :
+     * - automatic_cleaning (is automating cleaning necessary)
+     * - tags (are tags supported)
+     * - expired_read (is it possible to read expired cache records
+     *                 (for doNotTestCacheValidity option for example))
+     * - priority does the backend deal with priority when saving
+     * - infinite_lifetime (is infinite lifetime can work with this backend)
+     * - get_list (is it possible to get the list of cache ids and the complete list of tags)
+     *
+     * @return array associative of with capabilities
+     */
+    public function getCapabilities()
+    {
+        $capabilities = [
+            'automatic_cleaning' => true,
+            'tags' => false,
+            'expired_read' => false,
+            'priority' => false,
+            'infinite_lifetime' => false,
+            'get_list' => false,
+        ];
+
+        if ($this->isTagAware()) {
+            $capabilities['tags'] = true;
+        }
+
+        return $capabilities;
+    }
+
+    /**
+     * @return bool Can the caching adapter use Tags?
+     */
+    public function isTagAware()
+    {
+        if ($this->cache instanceof TagAwareAdapterInterface) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/classes/Gems/Cache/Backend/ZendCache.php
+++ b/classes/Gems/Cache/Backend/ZendCache.php
@@ -1,0 +1,212 @@
+<?php
+
+/**
+ * A Zend Cache 1 backend wrapper for Zend-Cache 2+
+ * Currently incomplete!
+ */
+
+namespace Gems\Cache\Backend;
+
+
+use Zend\Cache\Storage\StorageInterface;
+use Gems\Cache\Backend;
+
+class ZendCache extends Backend implements \Zend_Cache_Backend_ExtendedInterface
+{
+    /**
+     * @var StorageInterface Zend Cache storage interface
+     */
+    protected $cache;
+
+    public function __construct(StorageInterface $cache)
+    {
+        $this->cache = $cache;
+    }
+
+    /**
+     * Get the cache storage adapter
+     *
+     * @return StorageInterface
+     */
+    public function getCache()
+    {
+        return $this->cache;
+    }
+
+    /**
+     * Set the frontend directives
+     *
+     * @param array $directives assoc of directives
+     */
+    public function setDirectives($directives)
+    {
+        throw new \Exception('Setting of directives not supported in Zend 2 Cache');
+    }
+
+    /**
+     * Test if a cache is available for the given id and (if yes) return it (false else)
+     *
+     * Note : return value is always "string" (unserialization is done by the core not by the backend)
+     *
+     * @param  string $id Cache id
+     * @param  boolean $doNotTestCacheValidity If set to true, the cache validity won't be tested
+     * @return string|false cached datas
+     */
+    public function load($id, $doNotTestCacheValidity = false)
+    {
+        $this->cache->getItem($id);
+    }
+
+    /**
+     * Test if a cache is available or not (for the given id)
+     *
+     * @param  string $id cache id
+     * @return mixed|false (a cache is not available) or "last modified" timestamp (int) of the available cache record
+     */
+    public function test($id)
+    {
+        $this->cache->hasItem($id);
+    }
+
+    /**
+     * Save some string datas into a cache record
+     *
+     * Note : $data is always "string" (serialization is done by the
+     * core not by the backend)
+     *
+     * @param  string $data            Datas to cache
+     * @param  string $id              Cache id
+     * @param  array $tags             Array of strings, the cache record will be tagged by each string entry
+     * @param  int   $specificLifetime If != false, set a specific lifetime for this cache record (null => infinite lifetime)
+     * @return boolean true if no problem
+     */
+    public function save($data, $id, $tags = array(), $specificLifetime = false);
+
+    /**
+     * Remove a cache record
+     *
+     * @param  string $id Cache id
+     * @return boolean True if no problem
+     */
+    public function remove($id);
+
+    /**
+     * Clean some cache records
+     *
+     * Available modes are :
+     * Zend_Cache::CLEANING_MODE_ALL (default)    => remove all cache entries ($tags is not used)
+     * Zend_Cache::CLEANING_MODE_OLD              => remove too old cache entries ($tags is not used)
+     * Zend_Cache::CLEANING_MODE_MATCHING_TAG     => remove cache entries matching all given tags
+     *                                               ($tags can be an array of strings or a single string)
+     * Zend_Cache::CLEANING_MODE_NOT_MATCHING_TAG => remove cache entries not {matching one of the given tags}
+     *                                               ($tags can be an array of strings or a single string)
+     * Zend_Cache::CLEANING_MODE_MATCHING_ANY_TAG => remove cache entries matching any given tags
+     *                                               ($tags can be an array of strings or a single string)
+     *
+     * @param  string $mode Clean mode
+     * @param  array  $tags Array of tags
+     * @return boolean true if no problem
+     */
+    public function clean($mode = Zend_Cache::CLEANING_MODE_ALL, $tags = array());
+
+    /**
+     * Return an array of stored cache ids
+     *
+     * @return array array of stored cache ids (string)
+     */
+    public function getIds();
+
+    /**
+     * Return an array of stored tags
+     *
+     * @return array array of stored tags (string)
+     */
+    public function getTags();
+
+    /**
+     * Return an array of stored cache ids which match given tags
+     *
+     * In case of multiple tags, a logical AND is made between tags
+     *
+     * @param array $tags array of tags
+     * @return array array of matching cache ids (string)
+     */
+    public function getIdsMatchingTags($tags = array());
+
+    /**
+     * Return an array of stored cache ids which don't match given tags
+     *
+     * In case of multiple tags, a logical OR is made between tags
+     *
+     * @param array $tags array of tags
+     * @return array array of not matching cache ids (string)
+     */
+    public function getIdsNotMatchingTags($tags = array());
+
+    /**
+     * Return an array of stored cache ids which match any given tags
+     *
+     * In case of multiple tags, a logical AND is made between tags
+     *
+     * @param array $tags array of tags
+     * @return array array of any matching cache ids (string)
+     */
+    public function getIdsMatchingAnyTags($tags = array());
+
+    /**
+     * Return the filling percentage of the backend storage
+     *
+     * @return int integer between 0 and 100
+     */
+    public function getFillingPercentage();
+
+    /**
+     * Return an array of metadatas for the given cache id
+     *
+     * The array must include these keys :
+     * - expire : the expire timestamp
+     * - tags : a string array of tags
+     * - mtime : timestamp of last modification time
+     *
+     * @param string $id cache id
+     * @return array array of metadatas (false if the cache id is not found)
+     */
+    public function getMetadatas($id);
+
+    /**
+     * Give (if possible) an extra lifetime to the given cache id
+     *
+     * @param string $id cache id
+     * @param int $extraLifetime
+     * @return boolean true if ok
+     */
+    public function touch($id, $extraLifetime);
+
+    /**
+     * Return an associative array of capabilities (booleans) of the backend
+     *
+     * The array must include these keys :
+     * - automatic_cleaning (is automating cleaning necessary)
+     * - tags (are tags supported)
+     * - expired_read (is it possible to read expired cache records
+     *                 (for doNotTestCacheValidity option for example))
+     * - priority does the backend deal with priority when saving
+     * - infinite_lifetime (is infinite lifetime can work with this backend)
+     * - get_list (is it possible to get the list of cache ids and the complete list of tags)
+     *
+     * @return array associative of with capabilities
+     */
+    public function getCapabilities();
+
+    /**
+     * @return bool Can the caching adapter use Tags?
+     */
+    public function isTagAware()
+    {
+        if ($this->cache instanceof TaggableInterface) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/classes/GemsEscort.php
+++ b/classes/GemsEscort.php
@@ -344,60 +344,139 @@ class GemsEscort extends \MUtil_Application_Escort
         $exists      = false;
         $cachePrefix = GEMS_PROJECT_NAME . '_';
 
-
+        $defaultLifetime = null;
         // Check if APC extension is loaded and enabled
         if (\MUtil_Console::isConsole() && !ini_get('apc.enable_cli') && $useCache === 'apc') {
             // To keep the rest readable, we just fall back to File when apc is disabled on cli
-            $useCache = "File";
+            $useCache = "file";
         }
 
-        $defaultLifetime = null;
 
-        if ($useCache === 'apc' && extension_loaded('apc') && ini_get('apc.enabled')) {
-            //Add path to the prefix as APC is a SHARED cache
-            $cachePrefix .= md5(APPLICATION_PATH);
-            $cacheBackendOptions = array('cache_id_prefix' => $cachePrefix);
-
-            $cache = new \Symfony\Component\Cache\Adapter\TagAwareAdapter(
-                new \Symfony\Component\Cache\Adapter\ApcuAdapter($cachePrefix, $defaultLifetime)
-            );
-            $cacheBackend = new \Gems\Cache\Backend\Psr6Cache($cache);
-            $exists = true;
-        } else {
-            $namespace = '';
-            $directory = GEMS_ROOT_DIR . '/var/cache';
-            //$cache = new Symfony\Component\Cache\Simple\FilesystemCache($namespace, $defaultLifetime, $directory);
-            $cache = new \Symfony\Component\Cache\Adapter\TagAwareAdapter(
-                new \Symfony\Component\Cache\Adapter\FilesystemAdapter($namespace, $defaultLifetime, $directory)
-            );
-            $cacheBackend = new \Gems\Cache\Backend\Psr6Cache($cache);
-            $cacheBackendOptions = [];
-            if (!file_exists($directory)) {
-                if (@mkdir($directory, 0777, true)) {
+        switch ($useCache) {
+            case 'newFile':
+                if (!class_exists('\Symfony\Component\Cache\Adapter\FilesystemAdapter')) {
+                    error_log("Symfony filesystem cache not available!");
+                    break;
+                }
+                $namespace = '';
+                $cacheDir = GEMS_ROOT_DIR . '/var/cache';
+                //$cache = new Symfony\Component\Cache\Simple\FilesystemCache($namespace, $defaultLifetime, $directory);
+                $cache = new \Symfony\Component\Cache\Adapter\TagAwareAdapter(
+                    new \Symfony\Component\Cache\Adapter\FilesystemAdapter($namespace, $defaultLifetime, $cacheDir)
+                );
+                $cacheBackend = new \Gems\Cache\Backend\Psr6Cache($cache);
+                $cacheBackendOptions = [];
+                if (!file_exists($cacheDir)) {
+                    if (@mkdir($cacheDir, 0777, true)) {
+                        $exists = true;
+                    }
+                } else {
                     $exists = true;
                 }
-            } else {
-                $exists = true;
-            }
+                break;
+            case 'newZendFile':
+                if (!class_exists('\Zend\Cache\StorageFactory')) {
+                    error_log("Zend\Cache Filesystem cache not available!");
+                    break;
+                }
+                $cacheDir = GEMS_ROOT_DIR . "/var/cache/";
+                $cacheBackendOptions = array('cache_dir' => $cacheDir, 'cache_file_perm' => 0660);
+
+                $storage = \Zend\Cache\StorageFactory::factory([
+                    'adapter' => [
+                        'name' => 'filesystem',
+                        'options' => [
+                            'cache_dir' => $cacheDir,
+                            'file_permission' => 0660,
+                        ],
+                    ],
+                    'plugins' => array(
+                        // Don't throw exceptions on cache errors
+                        /*'exception_handler' => array(
+                            'throw_exceptions' => false
+                        ),*/
+                        // We store database rows on filesystem so we need to serialize them
+                        'Serializer'
+                    )
+                ]);
+
+                $cacheBackend = new \Gems\Cache\Backend\ZendCache($storage);
+
+                if (!file_exists($cacheDir)) {
+                    if (@mkdir($cacheDir, 0777, true)) {
+                        $exists = true;
+                    }
+                } else {
+                    $exists = true;
+                }
+                break;
+            case 'newApc':
+
+                if (!class_exists('\Symfony\Component\Cache\Adapter\ApcuAdapter')) {
+                    error_log("Symfony APCU cache not available!");
+                    break;
+                }
+                    if (extension_loaded('apc') && ini_get('apc.enabled')) {
+                    //Add path to the prefix as APC is a SHARED cache
+                    $cachePrefix .= md5(APPLICATION_PATH);
+                    $cacheBackendOptions = array('cache_id_prefix' => $cachePrefix);
+
+                    $cache = new \Symfony\Component\Cache\Adapter\TagAwareAdapter(
+                        new \Symfony\Component\Cache\Adapter\ApcuAdapter($cachePrefix, $defaultLifetime)
+                    );
+                    $cacheBackend = new \Gems\Cache\Backend\Psr6Cache($cache);
+                    $exists = true;
+                    break;
+                }
+                // Intentional fall through;
+
+            case 'apc':
+            case 'oldApc':
+                if (extension_loaded('apc') && ini_get('apc.enabled')) {
+                    //Add path to the prefix as APC is a SHARED cache
+                    $cachePrefix .= md5(APPLICATION_PATH);
+                    $cacheBackendOptions = array('cache_id_prefix' => $cachePrefix);
+                    $cacheBackend = new \Gems\Cache\Backend\Apc($cacheBackendOptions);
+                    $exists = true;
+                    break;
+                } else {
+                    error_log("APC cache extension not available! defaulting to file.");
+                }
+            // Intentional fall through;
+            case 'file':
+            case 'oldFile':
+            default:
+                $cacheBackend = 'File';
+                $cacheDir = GEMS_ROOT_DIR . "/var/cache/";
+                $cacheBackendOptions = array('cache_dir' => $cacheDir);
+                if (!file_exists($cacheDir)) {
+                    if (@mkdir($cacheDir, 0777, true)) {
+                        $exists = true;
+                    }
+                } else {
+                    $exists = true;
+                }
         }
+
         if ($exists && $useCache <> 'none') {
             /**
              * automatic_cleaning_factor disables automatic cleaning of the cache and should get rid of
              *                           random delays on heavy traffic sites with File cache. Apc does
              *                           not support automatic cleaning.
              */
-            $cacheFrontendOptions = array(
-                'automatic_serialization' => true,
+            $cacheFrontendOptions = array('automatic_serialization' => true,
                 'cache_id_prefix' => $cachePrefix,
-                'automatic_cleaning_factor' => 0
-            );
+                'automatic_cleaning_factor' => 0);
+
             $cache = \Zend_Cache::factory('Core', $cacheBackend, $cacheFrontendOptions, $cacheBackendOptions);
         } else {
             $cache = \Zend_Cache::factory('Core', 'Static', array('caching' => false), array('disable_caching' => true));
         }
+
         \Zend_Db_Table_Abstract::setDefaultMetadataCache($cache);
         \Zend_Translate::setCache($cache);
         \Zend_Locale::setCache($cache);
+
         return $cache;
     }
 

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,8 @@
         "zendframework/zend-db": "^2.8",
         "bacon/bacon-qr-code": "^1.0.3",
         "erusev/parsedown": "~1.7",
-        "ifsnop/mysqldump-php": "^2.6"
+        "ifsnop/mysqldump-php": "^2.6",
+        "symfony/cache": "^3.4"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*",


### PR DESCRIPTION
This Pull request fixes Cache issues with Zend Framework 1 in 3 ways:


1. ( 7939aadd8c055cccb201ac81614b44b70a21292a ) Gems\Cache\Backend\APC and Gems\Cache\Backend\File   Fix the PHP 7.2 deprecation of the each function by replacing it with a foreach. As far as I could see this is the only use of each or other deprecated functions in use in GemsTracker and should enable us to run Gemstracker on PHP 7.2.

2. ( 9f3d802b31f300cad0eeb1d8fa07495e00b44935 ) Gems\Cache\Backend\Psr6Cache and Gems\Cache\Backend\Psr16Cache implement the PHP-FIG cache standards for [Cache](https://www.php-fig.org/psr/psr-6/) and [SimpleCache](https://www.php-fig.org/psr/psr-16/). SimpleCache is a simplified cache without some functions like tag support. These Zend Cache backends are basically translators enabling to add any complient caching library, e.g. Symfony Cache. The benifit of this is that the adapters written for these standards should be complient with any cache library, thus making it a lot easier to support more caching adapters.
In Zend Expressive we could create a psr-6 caching library, add that to the servicemanager, then put the same cache in this adapter and load it as legacyCache, thus enabling us to use the legacy cache, but also write for the new cache.
By the time we have updated all code that uses Zend_Cache (also used in zend_db and zend_translator!) we can remove this. 

3. ( 2e914f8f30a0b2067a781dea97662c6316fad7d9 ) Gems\Cache\Backend\ZendCache is a specific backend that makes it possible to add Zend Cache 2 to Zend Cache 1. If we decide to stay with Zend as cache library supplier, this would be the way to go. Zend Cache is not PSR-6 complient, though it has an adapter for it. This implementation is not finished, quite a few methods are still empty, but it could serve as a start if the need is there to directly use Zend Cache

4. ( 8950af37ba4538ca40d7a1f418b183193404f2e4 ) This is an example of how Symfony Cache should be implemented in GemsEscort. For now we will use Symfony Cache 3.4, as it has LTS support until nov 2020, and Symfony 4.x versions require 7.1 or higher. The File Cache seems to work, I have not been able to try the APC cache. Small note is that Psr-16 has been removed from symfony cache since version 4.2.

At the very least I'd like to add the first to 1.8.7. Though the second would be good to add as well, making it possible to implement in projects until a required 1.8.8?

Lets discuss this first before actually merging!

