### PR TITLE
GemsTracker is not a replacement of zendframework

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -100,9 +100,6 @@
             "url": "https://github.com/MagnaFacta/zalt-loader.git"
         }
     ],
-    "replace": {
-        "zendframework/zendframework1": "1.*"
-    },
     "suggest": {
         "phpoffice/phpword": "Add v0.16.* to allow export to Word"
     }


### PR DESCRIPTION
This caused the inability to add a higher shardj/zf1-future version to a project, which would enable php 7.3 and 7.4 support