### PR TITLE
EmailSubscribeSnippet: Don't use 'no mail' code when subscribing

### DIFF
--- a/classes/Gems/Snippets/Subscribe/EmailSubscribeSnippet.php
+++ b/classes/Gems/Snippets/Subscribe/EmailSubscribeSnippet.php
@@ -102,7 +102,8 @@ class EmailSubscribeSnippet extends FormSnippetAbstract
         $model = $this->loader->getModels()->createRespondentModel();
 
         $mailCodes = $this->util->getDbLookup()->getRespondentMailCodes();
-        key($mailCodes);
+        // Use the second mailCode, the first is the no-mail code.
+        next($mailCodes);
         $mailable = key($mailCodes);
         
         $values['grs_iso_lang']         = $this->locale->getLanguage();


### PR DESCRIPTION
In my database, the first mail code is `0`, where `gmc_mail_cause_target` is `Never mail`. I assume this is not the correct code to use when subscribing, as this code is also used when unsubscribing.

This change ensures we use the second mail code (which has id `100` and `gmc_mail_cause_target` `Mail`), as I assume was the intention here.

Another option would be to use a hardcoded class value, like is done in https://github.com/GemsTracker/gemstracker-library/blob/master/classes/Gems/Snippets/Unsubscribe/EmailUnsubscribeSnippet.php#L61

If the database contents are different in live situations than this fix is incorrect; IMHO a better solution would not to rely on the order of mailcodes in the database, but to select the first mailcode where `gmc_mail_to_target` is `Yes`, or where `gmc_for_surveys` is `1`. Please advise.