### PR TITLE
2.x menualias

### DIFF
--- a/src/Config/Menu.php
+++ b/src/Config/Menu.php
@@ -1634,6 +1634,16 @@ class Menu
                     'label' => $this->translator->trans('Unsubscribe'),
                     'type' => 'route-link-item',
                 ],
+                [
+                    'name' => 'participate.subscribe-thanks',
+                    'type' => 'alias',
+                    'alias' => 'participate.subscribe',
+                ],
+                [
+                    'name' => 'participate.unsubscribe-thanks',
+                    'type' => 'alias',
+                    'alias' => 'participate.unsubscribe',
+                ],
             ],
         ];
     }

--- a/src/Menu/AliasItem.php
+++ b/src/Menu/AliasItem.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Gems\Menu;
+
+/**
+ * An invisible menu item. If the route associated with this menu item is
+ * currently active, the menu will not show this item but show the aliased
+ * item as active instead.
+ */
+class AliasItem extends MenuItem
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly string $alias,
+    ) {
+    }
+
+    protected function register()
+    {
+        $this->getMenu()->registerItem($this->name, $this);
+    }
+
+    protected function hasAccess(): bool
+    {
+        return false;
+    }
+
+    public function getLabel(): string
+    {
+        return '';
+    }
+
+    public function renderNode(): string
+    {
+        return '';
+    }
+}

--- a/src/Menu/Menu.php
+++ b/src/Menu/Menu.php
@@ -24,6 +24,7 @@ class Menu extends MenuNode
             $object = match($item['type']) {
                 'route', 'route-link-item' => new RouteLinkItem($item['name'], $item['label']),
                 'container' => new ContainerLinkItem($item['name'], $item['label']),
+                'alias' => new AliasItem($item['name'], $item['alias']),
                 default => throw new \Exception('Invalid type: ' . $item['type']),
             };
 
@@ -56,6 +57,10 @@ class Menu extends MenuNode
         return $this->items[$name] ?? throw new MenuItemNotFoundException($name);
     }
 
+    /**
+     * Make the menu item for this route and its parent items active.
+     * If the menu item is an alias, we open the aliased path instead.
+     */
     public function openRouteResult(RouteResult $routeResult): void
     {
         $name = $routeResult->getMatchedRouteName();
@@ -65,6 +70,12 @@ class Menu extends MenuNode
         }
 
         $item = $this->items[$name];
+        if ($item instanceof AliasItem) {
+            $alias = $item->alias;
+            if (isset($this->items[$alias])) {
+                $item = $this->items[$alias];
+            }
+        }
         $item->openPath($routeResult->getMatchedParams());
     }
 


### PR DESCRIPTION
Zoals vandaag besproken.

Een andere aanvliegroute zou nog kunnen zijn om de aliases in de route config op te nemen, en in openRouteResult() de call naar getMatchedRouteName() te vervangen door een call naar een functie die de aliases meeneemt.