### PR TITLE
paginator: Code moved to zalt-html

### DIFF
--- a/src/Html/Paginator/GemsPaginator.php
+++ b/src/Html/Paginator/GemsPaginator.php
@@ -55,8 +55,8 @@ class GemsPaginator extends \Zalt\Html\Paginator\LinkPaginator
 
     protected function getItems(): array
     {
-        $start = (($this->pageNumber - 1) * $this->pageItems) + 1;
-        $end   = min($this->pageNumber * $this->pageItems, $this->itemCount);
+        $start = $this->getFirstItem();
+        $end   = $this->getLastItem();
 
         return [
             sprintf($this->_('%d to '), $start),


### PR DESCRIPTION
Last fix for pagination. Requires https://github.com/MagnaFacta/zalt-html/pull/6 to be merged

Fixes the issue that the page controls show "1 to 0 of 0" on pages without any items.