### PR TITLE
Avoid double encapsulation of styles

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -441,7 +441,7 @@ class Model
         /**
          * @var $model OrganizationModel
          */
-        $model = $this->_createModel('OrganizationModel', [$styles]);
+        $model = $this->_createModel('OrganizationModel', $styles);
 
         return $model;
     }


### PR DESCRIPTION
The $styles variable already is an array, and should not be folded into an array again.
This caused the styles dropdown to be filled with a single value '0'.