### PR TITLE
Fix for Check all rounds function

### DIFF
--- a/src/Tracker/Engine/AnyStepEngine.php
+++ b/src/Tracker/Engine/AnyStepEngine.php
@@ -160,7 +160,7 @@ class AnyStepEngine extends StepEngineAbstract
      *
      * @param string $fieldSource Source for field from round
      * @param string $fieldName Name from round
-     * @param int $prevRoundId Id from round
+     * @param int|null $prevRoundId Id from round
      * @param \Gems\Tracker\Token $token
      * @param \Gems\Tracker\RespondentTrack $respTrack
      * @return ?DateTimeInterface date time or null

--- a/src/Tracker/Engine/NextStepEngine.php
+++ b/src/Tracker/Engine/NextStepEngine.php
@@ -176,12 +176,12 @@ class NextStepEngine extends \Gems\Tracker\Engine\StepEngineAbstract
      *
      * @param string $fieldSource Source for field from round
      * @param string $fieldName Name from round
-     * @param int $prevRoundId Id from round
+     * @param int|null $prevRoundId Id from round
      * @param \Gems\Tracker\Token $token
      * @param \Gems\Tracker\RespondentTrack $respTrack
      * @return ?DateTimeInterface date time or null
      */
-    protected function getValidFromDate(string $fieldSource, string $fieldName, int $prevRoundId, Token $token, RespondentTrack $respTrack): ?DateTimeInterface
+    protected function getValidFromDate(string $fieldSource, string $fieldName, int|null $prevRoundId, Token $token, RespondentTrack $respTrack): ?DateTimeInterface
     {
         $date = null;
 

--- a/src/Tracker/Engine/StepEngineAbstract.php
+++ b/src/Tracker/Engine/StepEngineAbstract.php
@@ -935,12 +935,12 @@ abstract class StepEngineAbstract extends TrackEngineAbstract
      *
      * @param string $fieldSource Source for field from round
      * @param string $fieldName Name from round
-     * @param int $prevRoundId Id from round
+     * @param int|null $prevRoundId Id from round
      * @param \Gems\Tracker\Token $token
      * @param \Gems\Tracker\RespondentTrack $respTrack
      * @return ?DateTimeInterface date time or null
      */
-    abstract protected function getValidFromDate(string $fieldSource, string $fieldName, int $prevRoundId, Token $token, RespondentTrack $respTrack): ?DateTimeInterface;
+    abstract protected function getValidFromDate(string $fieldSource, string $fieldName, int|null $prevRoundId, Token $token, RespondentTrack $respTrack): ?DateTimeInterface;
 
     /**
      * Returns the date to use to calculate the ValidUntil if any

--- a/src/Tracker/RespondentTrack.php
+++ b/src/Tracker/RespondentTrack.php
@@ -496,7 +496,10 @@ class RespondentTrack
                     }
                 }
 
-                $changes = $changes + $token->assignTo($relationId, $relationFieldId);
+                // We cannot assign the token if the relation is unknown.
+                if ($relationId) {
+                    $changes = $changes + $token->assignTo($relationId, $relationFieldId);
+                }
             }
         }
 


### PR DESCRIPTION
The 'Check all rounds' function didn't complete on the test hosts, because prevRoundId happened to be null, which caused a backtrace. Since AnyStepEngine already allowed prevRoundId to be null, I allowed this in the other StepEngine classes as well.
Also, don't try to assign if relationId is null.

Not sure if this should be a hard error instead.