### PR TITLE
2.x migrate round model

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,6 +68,7 @@
         "laminas/laminas-diactoros": "^2.11",
         "laminas/laminas-filter": "^2.17",
         "laminas/laminas-hydrator": "^4.5",
+        "laminas/laminas-i18n": "2.26.x-dev",
         "laminas/laminas-permissions-acl": "^2.9",
         "laminas/laminas-servicemanager": "^3.11",
         "laminas/laminas-stratigility": "^3.9.0",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -992,7 +992,7 @@ parameters:
 
 		-
 			message: "#^Expression on left side of \\?\\? is not nullable\\.$#"
-			count: 5
+			count: 1
 			path: src/ConfigProvider.php
 
 		-
@@ -2316,11 +2316,6 @@ parameters:
 			path: src/Handlers/Respondent/CalendarHandler.php
 
 		-
-			message: "#^Parameter \\#1 \\$format of method DateTimeImmutable\\:\\:format\\(\\) expects string, array given\\.$#"
-			count: 1
-			path: src/Handlers/Respondent/CalendarHandler.php
-
-		-
 			message: "#^Parameter \\#1 \\$targetModel of method Zalt\\\\Model\\\\Translator\\\\ModelTranslatorInterface\\:\\:setTargetModel\\(\\) expects Zalt\\\\Model\\\\Data\\\\DataWriterInterface, Zalt\\\\Model\\\\Data\\\\DataReaderInterface given\\.$#"
 			count: 1
 			path: src/Handlers/Respondent/CalendarHandler.php
@@ -2847,11 +2842,6 @@ parameters:
 
 		-
 			message: "#^Call to an undefined method Zalt\\\\Html\\\\Sequence\\:\\:pre\\(\\)\\.$#"
-			count: 2
-			path: src/Handlers/Setup/ProjectInformationHandler.php
-
-		-
-			message: "#^Parameter \\#1 \\$size of static method MUtil\\\\File\\:\\:getByteSized\\(\\) expects int, float given\\.$#"
 			count: 2
 			path: src/Handlers/Setup/ProjectInformationHandler.php
 
@@ -4661,41 +4651,6 @@ parameters:
 			path: src/Snippets/Agenda/AppointmentCheckSnippet.php
 
 		-
-			message: "#^Call to an undefined method MUtil\\\\Html\\\\Sequence\\:\\:br\\(\\)\\.$#"
-			count: 1
-			path: src/Snippets/Agenda/AppointmentCheckSnippet.php
-
-		-
-			message: "#^Call to an undefined method MUtil\\\\Html\\\\Sequence\\:\\:div\\(\\)\\.$#"
-			count: 1
-			path: src/Snippets/Agenda/AppointmentCheckSnippet.php
-
-		-
-			message: "#^Call to an undefined method MUtil\\\\Html\\\\Sequence\\:\\:h1\\(\\)\\.$#"
-			count: 1
-			path: src/Snippets/Agenda/AppointmentCheckSnippet.php
-
-		-
-			message: "#^Call to an undefined method MUtil\\\\Html\\\\Sequence\\:\\:h2\\(\\)\\.$#"
-			count: 3
-			path: src/Snippets/Agenda/AppointmentCheckSnippet.php
-
-		-
-			message: "#^Call to an undefined method MUtil\\\\Html\\\\Sequence\\:\\:ol\\(\\)\\.$#"
-			count: 2
-			path: src/Snippets/Agenda/AppointmentCheckSnippet.php
-
-		-
-			message: "#^Call to an undefined method MUtil\\\\Html\\\\Sequence\\:\\:pInfo\\(\\)\\.$#"
-			count: 4
-			path: src/Snippets/Agenda/AppointmentCheckSnippet.php
-
-		-
-			message: "#^Call to method findAllowedController\\(\\) on an unknown class Gems\\\\Menu\\.$#"
-			count: 5
-			path: src/Snippets/Agenda/AppointmentCheckSnippet.php
-
-		-
 			message: "#^Method Gems\\\\Snippets\\\\Agenda\\\\AppointmentCheckSnippet\\:\\:getMenuList\\(\\) has invalid return type Gems\\\\Menu\\\\MenuList\\.$#"
 			count: 1
 			path: src/Snippets/Agenda/AppointmentCheckSnippet.php
@@ -4717,11 +4672,6 @@ parameters:
 
 		-
 			message: "#^PHPDoc tag @return with type mixed is not subtype of native type string\\|null\\.$#"
-			count: 1
-			path: src/Snippets/Agenda/AppointmentCheckSnippet.php
-
-		-
-			message: "#^Property Gems\\\\Snippets\\\\Agenda\\\\AppointmentCheckSnippet\\:\\:\\$tracker \\(Gems\\\\Tracker\\) does not accept Gems\\\\Tracker\\\\TrackerInterface\\.$#"
 			count: 1
 			path: src/Snippets/Agenda/AppointmentCheckSnippet.php
 
@@ -5306,11 +5256,6 @@ parameters:
 			path: src/Snippets/Export/ExportFormSnippet.php
 
 		-
-			message: "#^Method Gems\\\\Snippets\\\\Export\\\\ExportFormSnippet\\:\\:getHtmlOutput\\(\\) should return MUtil\\\\Html\\\\HtmlInterface but returns Zalt\\\\Html\\\\HtmlElement\\.$#"
-			count: 1
-			path: src/Snippets/Export/ExportFormSnippet.php
-
-		-
 			message: "#^Parameter \\#2 \\$code of class Zalt\\\\SnippetsLoader\\\\SnippetException constructor expects int, class\\-string\\|false given\\.$#"
 			count: 1
 			path: src/Snippets/Export/ExportFormSnippet.php
@@ -5614,11 +5559,6 @@ parameters:
 			message: "#^Property Gems\\\\Snippets\\\\FormSnippetAbstractMUtil\\:\\:\\$menu has unknown class Gems\\\\Menu as its type\\.$#"
 			count: 1
 			path: src/Snippets/FormSnippetAbstractMUtil.php
-
-		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$menuList$#"
-			count: 1
-			path: src/Snippets/Generic/ButtonRowSnippet.php
 
 		-
 			message: "#^Access to an undefined property MUtil\\\\Html\\\\TableElement\\:\\:\\$class\\.$#"
@@ -6013,11 +5953,6 @@ parameters:
 		-
 			message: "#^Call to an undefined method Zalt\\\\Model\\\\Bridge\\\\FormBridgeInterface\\:\\:addTab\\(\\)\\.$#"
 			count: 2
-			path: src/Snippets/ModelFormSnippetAbstract.php
-
-		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$menuList$#"
-			count: 1
 			path: src/Snippets/ModelFormSnippetAbstract.php
 
 		-
@@ -7866,24 +7801,9 @@ parameters:
 			path: src/Snippets/Tracker/InsertSurveySnippet.php
 
 		-
-			message: "#^Parameter \\#1 \\$model of method Gems\\\\Tracker\\\\Engine\\\\StepEngineAbstract\\:\\:updateRoundModelToItem\\(\\) expects Zalt\\\\Model\\\\MetaModelInterface, Zalt\\\\Model\\\\Data\\\\DataReaderInterface given\\.$#"
-			count: 1
-			path: src/Snippets/Tracker/Rounds/EditRoundStepSnippet.php
-
-		-
-			message: "#^Call to an undefined method Zalt\\\\Model\\\\Data\\\\DataReaderInterface\\:\\:get\\(\\)\\.$#"
-			count: 11
-			path: src/Snippets/Tracker/Rounds/RoundsTableSnippet.php
-
-		-
 			message: "#^Property Gems\\\\Snippets\\\\Tracker\\\\Rounds\\\\RoundsTableSnippet\\:\\:\\$menuActionController \\(array\\) does not accept default value of type string\\.$#"
 			count: 1
 			path: src/Snippets/Tracker/Rounds/RoundsTableSnippet.php
-
-		-
-			message: "#^PHPDoc tag @param for parameter \\$bridge with type MUtil\\\\Model\\\\Bridge\\\\VerticalTableBridge is incompatible with native type Zalt\\\\Snippets\\\\ModelBridge\\\\DetailTableBridge\\.$#"
-			count: 1
-			path: src/Snippets/Tracker/Rounds/ShowRoundStepSnippet.php
 
 		-
 			message: "#^Access to an undefined property Gems\\\\Snippets\\\\Tracker\\\\ShowTrackUsageSnippet\\:\\:\\$menu\\.$#"
@@ -8531,7 +8451,17 @@ parameters:
 			path: src/Tracker/Engine/StepEngineAbstract.php
 
 		-
+			message: "#^Call to an undefined method Gems\\\\Tracker\\\\Model\\\\RoundModel\\:\\:saveAll\\(\\)\\.$#"
+			count: 1
+			path: src/Tracker/Engine/TrackEngineAbstract.php
+
+		-
 			message: "#^Call to function is_null\\(\\) with \\(0\\|''\\|'0'\\) will always evaluate to false\\.$#"
+			count: 1
+			path: src/Tracker/Engine/TrackEngineAbstract.php
+
+		-
+			message: "#^Method Zalt\\\\Model\\\\Sql\\\\JoinModel\\:\\:loadNew\\(\\) invoked with 1 parameter, 0 required\\.$#"
 			count: 1
 			path: src/Tracker/Engine/TrackEngineAbstract.php
 
@@ -8674,16 +8604,6 @@ parameters:
 			message: "#^Parameter \\#1 \\$array of function key expects array\\|object, int given\\.$#"
 			count: 1
 			path: src/Tracker/Model/RespondentTrackModel.php
-
-		-
-			message: "#^Method Gems\\\\Tracker\\\\Model\\\\RoundModel\\:\\:getRefCount\\(\\) should return int but returns string\\|false\\|null\\.$#"
-			count: 1
-			path: src/Tracker/Model/RoundModel.php
-
-		-
-			message: "#^Method Gems\\\\Tracker\\\\Model\\\\RoundModel\\:\\:getStartCount\\(\\) should return int but returns string\\|false\\|null\\.$#"
-			count: 1
-			path: src/Tracker/Model/RoundModel.php
 
 		-
 			message: "#^Access to an undefined property Gems\\\\Util\\\\Translated\\:\\:\\$formatDateTimeNa\\.$#"

--- a/src/Locale/Locale.php
+++ b/src/Locale/Locale.php
@@ -16,7 +16,7 @@ class Locale
             $this->config = $config['locale'];
         }
 
-        $this->currentLanguage = $this->getDefaultLanguage();
+        $this->setCurrentLanguage($this->getDefaultLanguage());
     }
 
     public function getAvailableLanguages(): array
@@ -90,6 +90,7 @@ class Locale
      */
     public function setCurrentLanguage(string $currentLanguage): void
     {
+        \Locale::setDefault($currentLanguage);
         $this->currentLanguage = $currentLanguage;
     }
 }

--- a/src/Model/Dependency/Condition/RoundDependency.php
+++ b/src/Model/Dependency/Condition/RoundDependency.php
@@ -92,9 +92,9 @@ class RoundDependency extends DependencyAbstract
                 $condition = $this->conditionLoader->loadCondition($context['gro_condition']);
                 $callback  = [$condition, 'isValid'];
                 $validator = new Callback($callback);
-                $validator->setMessage($condition->getNotValidReason($context['gro_condition'], $context), $validator::INVALID_VALUE);                    
+                $validator->setMessage($condition->getNotValidReason($context['gro_condition'], $context), $validator::INVALID_VALUE);
 
-                return [                
+                return [
                     'condition_display' => [
                         'elementClass' => 'Exhibitor',
                         'value' => $condition->getRoundDisplay((int)$context['gro_id_track'], (int)$context['gro_id_round'])
@@ -112,11 +112,11 @@ class RoundDependency extends DependencyAbstract
                 ];
             }
         }
-        
-        return [ 
+
+        return [
             'condition_display' => [
                 'elementClass' => 'Hidden',
-                'value' => null                
+                'value' => ''
             ]
         ];
     }

--- a/src/Model/JoinModel.php
+++ b/src/Model/JoinModel.php
@@ -67,7 +67,7 @@ class JoinModel extends \MUtil\Model\JoinModel
         $matches = [];
         preg_match_all('/([a-z]\w+\.[a-z][1-2a-z]+_\w+|[a-z][1-2a-z]+_\w+)/i', $expression, $matches);
         // \MUtil\EchoOut\EchoOut::track($expression, array_unique($matches[0]));
-        
+
         foreach (array_unique($matches[0]) as $field) {
             switch (strtoupper($field)) {
                 case 'CONCAT_WS':
@@ -82,7 +82,7 @@ class JoinModel extends \MUtil\Model\JoinModel
                 case 'TIME_FORMAT':
                     // do nothing for common functions
                     break;
-                    
+
                 default:
                     $this->_findFieldTable($tables, $field);
             }
@@ -98,7 +98,7 @@ class JoinModel extends \MUtil\Model\JoinModel
         // Check for tablename.fieldname, unless the field name is an aliased table
         if ((! $this->has($field)) && \MUtil\StringUtil\StringUtil::contains($field, '.')) {
             list($table, $newField) = explode('.', $field, 2);
-            
+
             if ($table == $this->get($newField, 'table')) {
                 $field = $newField;
             }
@@ -113,7 +113,7 @@ class JoinModel extends \MUtil\Model\JoinModel
                     }
                 }
             }
-            
+
             $tables[$table] = $table;
         }
     }
@@ -209,7 +209,7 @@ class JoinModel extends \MUtil\Model\JoinModel
     }
 
     /**
-     * Get a minimized select statement with a less complicated join using only the fields in the filter  
+     * Get a minimized select statement with a less complicated join using only the fields in the filter
      *
      * @param array $filter Filter array, num keys contain fixed expresions, text keys are equal or one of filters
      * @param array $cols Optional fields to return in the select
@@ -222,11 +222,11 @@ class JoinModel extends \MUtil\Model\JoinModel
         }
         // Remove selector fields
         unset($filter['limit'], $filter['page'], $filter['items']);
-        
+
         $filter = $this->_checkFilterUsed($filter);
-        
+
         $baseSelect = $this->getSelect();
-        
+
         $usedTables = [];
         foreach ($cols as $alias => $field) {
             $this->_findFieldTable($usedTables, $field);
@@ -257,7 +257,7 @@ class JoinModel extends \MUtil\Model\JoinModel
                     case \Zend_Db_Select::LEFT_JOIN:
                         $outputSelect->joinLeft($joinTable, $froms[$table]['joinCondition'], []);
                         break;
-                        
+
                     case \Zend_Db_Select::RIGHT_JOIN:
                         $outputSelect->joinRight($joinTable, $froms[$table]['joinCondition'], []);
                         break;

--- a/src/Snippets/ModelConfirmDeleteSnippetAbstract.php
+++ b/src/Snippets/ModelConfirmDeleteSnippetAbstract.php
@@ -134,7 +134,7 @@ abstract class ModelConfirmDeleteSnippetAbstract extends \Zalt\Snippets\ModelCon
         }
 
         // Set correct route
-        if ($output != DeleteModeEnum::Delete) {
+        if ($output !== DeleteModeEnum::Delete) {
             $this->deleteRoute = 'show';
         }
         $route = $this->menuSnippetHelper->getRelatedRoute($this->deleteRoute);

--- a/src/Snippets/Track/TrackDeleteSnippet.php
+++ b/src/Snippets/Track/TrackDeleteSnippet.php
@@ -69,12 +69,12 @@ class TrackDeleteSnippet extends ModelConfirmDeleteSnippetAbstract
 
     protected function getDeletionMode(DataReaderInterface $dataModel): DeleteModeEnum
     {
-        $output = parent::getDeletionMode($dataModel);
+        $this->deletionMode = parent::getDeletionMode($dataModel);
 
         if ($dataModel instanceof TrackModel) {
             $this->useCount = $dataModel->getStartCount($this->trackId);
 
-            if ($this->useCount) {
+            if ($this->useCount !== 0) {
                 $this->messenger->addMessage(sprintf($this->plural(
                     'This track has been started %s time.', 'This track has been started %s times.',
                     $this->useCount
@@ -82,13 +82,19 @@ class TrackDeleteSnippet extends ModelConfirmDeleteSnippetAbstract
                 $this->messenger->addMessage($this->_('This track cannot be deleted, only deactivated.'));
 
                 $this->question = $this->_('Do you want to deactivate this track?');
-                // $this->displayTitle   = $this->_('Deactivate track');
 
-                $output = DeleteModeEnum::Activate;
+                $this->deletionMode = DeleteModeEnum::Activate;
+            } else {
+                $this->deletionMode = DeleteModeEnum::Delete;
             }
         }
 
-        return $output;
+        return $this->deletionMode;
+    }
+
+    protected function setAfterActionRoute(): void
+    {
+        $this->afterActionRouteUrl = $this->menuSnippetHelper->getRouteUrl('track-builder.track-maintenance.index');
     }
 
     /**

--- a/src/Snippets/Tracker/Rounds/ConditionRoundsTableSnippet.php
+++ b/src/Snippets/Tracker/Rounds/ConditionRoundsTableSnippet.php
@@ -14,7 +14,6 @@ namespace Gems\Snippets\Tracker\Rounds;
 use Gems\Condition\ConditionInterface;
 use Gems\Condition\RoundConditionInterface;
 use Gems\Menu\MenuSnippetHelper;
-use Gems\Menu\RouteHelper;
 use Gems\Snippets\ModelTableSnippetAbstract;
 use Gems\Tracker\Model\RoundModel;
 use Gems\Util\Translated;

--- a/src/Snippets/Tracker/Rounds/EditRoundStepSnippet.php
+++ b/src/Snippets/Tracker/Rounds/EditRoundStepSnippet.php
@@ -48,7 +48,17 @@ class EditRoundStepSnippet extends EditRoundSnippetAbstract
         CurrentUserRepository $currentUserRepository,
         protected Locale $locale,
     ) {
-        parent::__construct($snippetOptions, $requestInfo, $translate, $messenger, $auditLog, $menuHelper, $tracker, $trackDataRepository, $currentUserRepository);
+        parent::__construct(
+            $snippetOptions,
+            $requestInfo,
+            $translate,
+            $messenger,
+            $auditLog,
+            $menuHelper,
+            $tracker,
+            $trackDataRepository,
+            $currentUserRepository
+        );
     }
 
     /**
@@ -61,8 +71,13 @@ class EditRoundStepSnippet extends EditRoundSnippetAbstract
         parent::loadFormData();
 
         if ($this->trackEngine instanceof StepEngineAbstract) {
-            if ($this->trackEngine->updateRoundModelToItem($this->getModel(), $this->formData, $this->locale->getLanguage())) {
-
+            if (
+                $this->trackEngine->updateRoundModelToItem(
+                    $this->getModel()->getMetaModel(),
+                    $this->formData,
+                    $this->locale->getLanguage()
+                )
+            ) {
                 if (isset($this->formData[$this->saveButtonId])) {
                     // Disable validation & save
                     unset($this->formData[$this->saveButtonId]);

--- a/src/Snippets/Tracker/Rounds/RoundDeleteSnippet.php
+++ b/src/Snippets/Tracker/Rounds/RoundDeleteSnippet.php
@@ -72,11 +72,6 @@ class RoundDeleteSnippet extends ModelConfirmDeleteSnippetAbstract
             $this->model = $this->trackEngine->getRoundModel(false, 'index');
         }
 
-        // Now add the joins so we can sort on the real name
-        // $this->model->addTable('gems__surveys', array('gro_id_survey' => 'gsu_id_survey'));
-
-        // $this->model->set('gsu_survey_name', $this->model->get('gro_id_survey'));
-
         return $this->model;
     }
 

--- a/src/Snippets/Tracker/Rounds/RoundsTableSnippet.php
+++ b/src/Snippets/Tracker/Rounds/RoundsTableSnippet.php
@@ -147,11 +147,6 @@ class RoundsTableSnippet extends ModelTableSnippetAbstract
         return parent::cleanUpFilter($filter, $metaModel);
     }
 
-    /**
-     * Creates the model
-     *
-     * @return \MUtil\Model\ModelAbstract
-     */
     protected function createModel(): DataReaderInterface
     {
         if (! $this->model instanceof RoundModel) {

--- a/src/Snippets/Tracker/Rounds/RoundsTableSnippet.php
+++ b/src/Snippets/Tracker/Rounds/RoundsTableSnippet.php
@@ -98,21 +98,23 @@ class RoundsTableSnippet extends ModelTableSnippetAbstract
      */
     protected function addBrowseTableColumns(TableBridge $bridge, DataReaderInterface $dataModel)
     {
-        // Make sure these fields are loaded
-        $dataModel->get('gro_valid_after_field');
-        $dataModel->get('gro_valid_after_id');
-        $dataModel->get('gro_valid_after_length');
-        $dataModel->get('gro_valid_after_source');
-        $dataModel->get('gro_valid_after_unit');
+        $metaModel = $dataModel->getMetaModel();
 
-        $dataModel->get('gro_valid_for_field');
-        $dataModel->get('gro_valid_for_id');
-        $dataModel->get('gro_valid_for_length');
-        $dataModel->get('gro_valid_for_source');
-        $dataModel->get('gro_valid_for_unit');
+        // Make sure these fields are loaded
+        $metaModel->get('gro_valid_after_field');
+        $metaModel->get('gro_valid_after_id');
+        $metaModel->get('gro_valid_after_length');
+        $metaModel->get('gro_valid_after_source');
+        $metaModel->get('gro_valid_after_unit');
+
+        $metaModel->get('gro_valid_for_field');
+        $metaModel->get('gro_valid_for_id');
+        $metaModel->get('gro_valid_for_length');
+        $metaModel->get('gro_valid_for_source');
+        $metaModel->get('gro_valid_for_unit');
 
         // We want to markt the row for inactive surveys so it visually stands out
-        $dataModel->get('gsu_active');
+        $metaModel->get('gsu_active');
 //        $bridge->tr()->appendAttrib('class', \MUtil\Lazy::iif(
 //            $bridge->gsu_active,
 //            '',
@@ -154,7 +156,7 @@ class RoundsTableSnippet extends ModelTableSnippetAbstract
     {
         if (! $this->model instanceof RoundModel) {
             $this->model = $this->trackEngine->getRoundModel(false, 'index');
-            $this->model->setKeys(['rid' => 'gro_id_round']);
+            $this->model->getMetaModel()->setKeys(['rid' => 'gro_id_round']);
         }
         $this->extraFilter['gro_id_track'] = $this->trackEngine->getTrackId();
 
@@ -178,10 +180,10 @@ class RoundsTableSnippet extends ModelTableSnippetAbstract
         $this->columns[50] = [$fromHeader,'gro_valid_after_field', $sp, 'gro_valid_after_source', $sp, 'gro_valid_after_id'];
         $this->columns[60] = [$untilHeader, 'gro_valid_for_field', $sp, 'gro_valid_for_source', $sp, 'gro_valid_for_id'];
         $this->columns[70] = ['gro_active'];
-        if ($label = $this->model->get('gro_changed_event', 'label')) {
+        if ($this->model->getMetaModel()->get('gro_changed_event', 'label')) {
             $this->columns[80] = ['gro_changed_event'];
         }
-        if ($label = $this->model->get('gro_changed_event', 'label')) {
+        if ($this->model->getMetaModel()->get('gro_changed_event', 'label')) {
             $this->columns[90] = ['gro_display_event'];
         }
         $this->columns[100] = ['gro_code'];

--- a/src/Snippets/Tracker/Rounds/ShowRoundStepSnippet.php
+++ b/src/Snippets/Tracker/Rounds/ShowRoundStepSnippet.php
@@ -80,17 +80,17 @@ class ShowRoundStepSnippet extends ShowRoundSnippetAbstract
      *
      * Overrule this function to add different columns to the browse table, without
      * having to recode the core table building code.
-     *
-     * @param \MUtil\Model\Bridge\VerticalTableBridge $bridge
-     * @param \MUtil\Model\ModelAbstract $dataModel
-     * @return void
      */
-    protected function addShowTableRows(DetailTableBridge $bridge, DataReaderInterface $dataModel)
+    protected function addShowTableRows(DetailTableBridge $bridge, DataReaderInterface $dataModel): void
     {
         $this->_roundData = $bridge->getRow();
 
         if ($this->trackEngine instanceof StepEngineAbstract && $this->_roundData) {
-            $this->trackEngine->updateRoundModelToItem($dataModel, $this->_roundData, $this->locale->getLanguage());
+            $this->trackEngine->updateRoundModelToItem(
+                $dataModel->getMetaModel(),
+                $this->_roundData,
+                $this->locale->getLanguage()
+            );
         }
 
         $bridge->addItem('gro_id_track');
@@ -99,31 +99,31 @@ class ShowRoundStepSnippet extends ShowRoundSnippetAbstract
         $bridge->addItem('gro_id_order');
         $bridge->addItem('gro_icon_file');
 
-        if ($dataModel->has('ggp_name')) {
+        if ($dataModel->getMetaModel()->has('ggp_name')) {
             $bridge->addItem('ggp_name');
-        } elseif ($dataModel->has('gro_id_relationfield')) {
+        } elseif ($dataModel->getMetaModel()->has('gro_id_relationfield')) {
             $bridge->addItem('gro_id_relationfield');
         }
 
         $bridge->addItem('valid_after');
 
         $this->_addIf(array('gro_valid_after_source', 'gro_valid_after_id', 'gro_valid_after_field'), $bridge, $dataModel);
-        if ($dataModel->has('gro_valid_after_length', 'label')) {
+//        if ($dataModel->has('gro_valid_after_length', 'label')) {
             //$bridge->addItem(array($bridge->gro_valid_after_length, ' ', $bridge->gro_valid_after_unit), $dataModel->get('gro_valid_after_length', 'label'));
-        }
+//        }
 
         //$bridge->addItem($dataModel->get('valid_for', 'value'));
         $this->_addIf(array('gro_valid_for_source', 'gro_valid_for_id', 'gro_valid_for_field'), $bridge, $dataModel);
-        if ($dataModel->has('gro_valid_for_length', 'label')) {
+//        if ($dataModel->has('gro_valid_for_length', 'label')) {
             //$bridge->addItem(array($bridge->gro_valid_for_length, ' ', $bridge->gro_valid_for_unit), $dataModel->get('gro_valid_after_length', 'label'));
-        }
+//        }
 
         $bridge->addItem('valid_cond');
         $bridge->addItem('condition_display');
 
         $bridge->addItem('gro_active');
         // Prevent empty row when no changed events exist
-        if ($label = $dataModel->get('gro_changed_event', 'label')) {
+        if ($dataModel->getMetaModel()->get('gro_changed_event', 'label')) {
             $bridge->addItem('gro_changed_event');
         }
         $bridge->addItem('gro_code');

--- a/src/Snippets/Tracker/Rounds/ShowRoundStepSnippet.php
+++ b/src/Snippets/Tracker/Rounds/ShowRoundStepSnippet.php
@@ -108,15 +108,8 @@ class ShowRoundStepSnippet extends ShowRoundSnippetAbstract
         $bridge->addItem('valid_after');
 
         $this->_addIf(array('gro_valid_after_source', 'gro_valid_after_id', 'gro_valid_after_field'), $bridge, $dataModel);
-//        if ($dataModel->has('gro_valid_after_length', 'label')) {
-            //$bridge->addItem(array($bridge->gro_valid_after_length, ' ', $bridge->gro_valid_after_unit), $dataModel->get('gro_valid_after_length', 'label'));
-//        }
 
-        //$bridge->addItem($dataModel->get('valid_for', 'value'));
         $this->_addIf(array('gro_valid_for_source', 'gro_valid_for_id', 'gro_valid_for_field'), $bridge, $dataModel);
-//        if ($dataModel->has('gro_valid_for_length', 'label')) {
-            //$bridge->addItem(array($bridge->gro_valid_for_length, ' ', $bridge->gro_valid_for_unit), $dataModel->get('gro_valid_after_length', 'label'));
-//        }
 
         $bridge->addItem('valid_cond');
         $bridge->addItem('condition_display');

--- a/src/Snippets/Tracker/TrackSurveyOverviewSnippet.php
+++ b/src/Snippets/Tracker/TrackSurveyOverviewSnippet.php
@@ -71,7 +71,7 @@ class TrackSurveyOverviewSnippet extends \Zalt\Snippets\TranslatableSnippetAbstr
     {
         parent::__construct($snippetOptions, $requestInfo, $translate);
     }
-    
+
     /**
      * Create the snippets content
      *
@@ -110,19 +110,9 @@ class TrackSurveyOverviewSnippet extends \Zalt\Snippets\TranslatableSnippetAbstr
             $this->trackEngine = $this->tracker->getTrackEngine($trackId);
         }
 
-        $roundModel = $this->trackEngine->getRoundModel(true, 'index');
-        
-        // The conditions seem to break the iterator, load only fields we need for display so the conditions won't be triggered
-        $roundModel->trackUsage();
-        $roundModel->get('gro_id_track');
-        $roundModel->get('gsu_id_survey');
-        $roundModel->get('gsu_survey_name');
-        $roundModel->get('gro_icon_file');
-        $roundModel->get('gro_round_description');
-        $roundModel->get('ggp_name');
-        $roundModel->get('gsu_survey_description');
-        
-        return $roundModel->loadRepeatable(array('gro_id_track' => $trackId, 'gro_active' => 1));
+        return $this->trackEngine
+            ->getRoundModel(true, 'index')
+            ->loadRepeatable(array('gro_id_track' => $trackId, 'gro_active' => 1));
     }
 
     /**

--- a/src/Tracker/Engine/AnyStepEngine.php
+++ b/src/Tracker/Engine/AnyStepEngine.php
@@ -149,8 +149,9 @@ class AnyStepEngine extends StepEngineAbstract
     {
         $model = parent::getRoundModel($detailed, $action);
 
-        $model->set('gro_valid_for_id',
-                'default', '0');
+        $model->getMetaModel()->set('gro_valid_for_id', [
+            'default' => '0'
+        ]);
 
         return $model;
     }

--- a/src/Tracker/Engine/StepEngineAbstract.php
+++ b/src/Tracker/Engine/StepEngineAbstract.php
@@ -705,7 +705,8 @@ abstract class StepEngineAbstract extends TrackEngineAbstract
             $metaModel->set('gro_valid_after_length', [
                 'label' => $this->translator->_('Add to date'),
                 'description' => $this->translator->_('Can be negative'),
-                'required' => false,
+                'required' => true,
+                'default' => 10,
                 'filter' => new NumberFormat(),
                 'validator' => new IsInt()
             ]);
@@ -768,7 +769,7 @@ abstract class StepEngineAbstract extends TrackEngineAbstract
             $metaModel->set('gro_valid_for_length', [
                 'label' => $this->translator->_('Add to date'),
                 'description' => $this->translator->_('Can be negative'),
-                'required' => false,
+                'required' => true,
                 'default' => 2,
                 'filter' => new NumberFormat(),
                 'validator' => new IsInt()

--- a/src/Tracker/Engine/StepEngineAbstract.php
+++ b/src/Tracker/Engine/StepEngineAbstract.php
@@ -652,7 +652,7 @@ abstract class StepEngineAbstract extends TrackEngineAbstract
         // Add information about surveys and groups
         $model->addLeftTable('gems__surveys', ['gro_id_survey' => 'gsu_id_survey']);
         $model->addLeftTable('gems__groups', ['gsu_id_primary_group' => 'ggp_id_group']);
-        $model->addLeftTable('gems__track_fields', ['gro_id_relationfield = gtf_id_field'], 'gtf', false);
+        $model->addLeftTable('gems__track_fields', ['gro_id_relationfield = gtf_id_field'], false, 'gtf');
 
         $model->addColumn(new Expression('COALESCE(gtf_field_name, ggp_name)'), 'ggp_name');
         $metaModel->set('ggp_name', ['label' => $this->translator->_('Assigned to')]);

--- a/src/Tracker/Engine/StepEngineAbstract.php
+++ b/src/Tracker/Engine/StepEngineAbstract.php
@@ -36,7 +36,10 @@ use Gems\Tracker\TrackEvents;
 use Gems\Translate\DbTranslationRepository;
 use Gems\User\User;
 use Gems\Util\Translated;
+use Laminas\Db\Sql\Expression;
 use Laminas\Filter\Digits;
+use Laminas\I18n\Filter\NumberFormat;
+use Laminas\I18n\Validator\IsInt;
 use MUtil\Model\TableModel;
 use MUtil\Ra;
 use MUtil\Translate\Translator;
@@ -644,165 +647,169 @@ abstract class StepEngineAbstract extends TrackEngineAbstract
     public function getRoundModel(bool $detailed, string $action): RoundModel
     {
         $model = parent::getRoundModel($detailed, $action);
+        $metaModel = $model->getMetaModel();
 
         // Add information about surveys and groups
         $model->addLeftTable('gems__surveys', ['gro_id_survey' => 'gsu_id_survey']);
         $model->addLeftTable('gems__groups', ['gsu_id_primary_group' => 'ggp_id_group']);
         $model->addLeftTable('gems__track_fields', ['gro_id_relationfield = gtf_id_field'], 'gtf', false);
 
-        $model->addColumn(new \Zend_Db_Expr('COALESCE(gtf_field_name, ggp_name)'), 'ggp_name');
-        $model->set('ggp_name', 'label', $this->translator->_('Assigned to'));
+        $model->addColumn(new Expression('COALESCE(gtf_field_name, ggp_name)'), 'ggp_name');
+        $metaModel->set('ggp_name', ['label' => $this->translator->_('Assigned to')]);
 
         // Reset display order to class specific order
-        $model->resetOrder();
+        $metaModel->resetOrder();
         if (! $detailed) {
-            $model->set('gro_id_order');
+            $metaModel->set('gro_id_order');
         }
-        $model->set('gro_id_track');
-        $model->set('gro_id_survey');
-        $model->set('gro_round_description');
+        $metaModel->set('gro_id_track');
+        $metaModel->set('gro_id_survey');
+        $metaModel->set('gro_round_description');
         if ($detailed) {
-            $model->set('gro_id_order');
+            $metaModel->set('gro_id_order');
         }
-        $model->set('gro_icon_file');
+        $metaModel->set('gro_icon_file');
 
         // Calculate valid from
         if ($detailed) {
             $html = \Zalt\Html\Html::create()->h4($this->translator->_('Valid from calculation'));
-            $model->set('valid_after',
-                    'default', $html,
-                    'label', ' ',
-                    'elementClass', 'html',
-                    'value', $html
-                    );
+            $metaModel->set('valid_after', [
+                'default' => $html,
+                'label' => ' ',
+                'elementClass' => 'html',
+                'value' => $html
+            ]);
         }
-        $model->set('gro_valid_after_source',
-                'label', $this->translator->_('Date source'),
-                'default', self::TOKEN_TABLE,
-                'elementClass', 'Radio',
-                'escape', false,
-                'required', true,
-                'autoSubmit', true,
-                'multiOptions', $this->getSourceList(true, false, false)
-                );
-        $model->set('gro_valid_after_id',
-                'label', $this->translator->_('Round used'),
-                'autoSubmit', true
-                );
+        $metaModel->set('gro_valid_after_source', [
+            'label' => $this->translator->_('Date source'),
+            'default' => self::TOKEN_TABLE,
+            'elementClass' => 'Radio',
+            'escape' => false,
+            'required' => true,
+            'autoSubmit' => true,
+            'multiOptions' => $this->getSourceList(true, false, false)
+        ]);
+        $metaModel->set('gro_valid_after_id', [
+            'label' => $this->translator->_('Round used'),
+            'autoSubmit' => true
+        ]);
 
         if ($detailed) {
             $periodUnits = $this->translatedUtil->getPeriodUnits();
 
-            $model->set('gro_valid_after_field',
-                    'label', $this->translator->_('Date used'),
-                    'default', 'gto_valid_from',
-                    'autoSubmit', true
-                    );
-            $model->set('gro_valid_after_length',
-                    'label', $this->translator->_('Add to date'),
-                    'description', $this->translator->_('Can be negative'),
-                    'required', false,
-                    'filter', Digits::class
-                    );
-            $model->set('gro_valid_after_unit',
-                    'label', $this->translator->_('Add to date unit'),
-                    'multiOptions', $periodUnits
-                    );
+            $metaModel->set('gro_valid_after_field', [
+                'label' => $this->translator->_('Date used'),
+                'default' => 'gto_valid_from',
+                'autoSubmit' => true
+            ]);
+            $metaModel->set('gro_valid_after_length', [
+                'label' => $this->translator->_('Add to date'),
+                'description' => $this->translator->_('Can be negative'),
+                'required' => false,
+                'filter' => new NumberFormat(),
+                'validator' => new IsInt()
+            ]);
+            $metaModel->set('gro_valid_after_unit', [
+                'label' => $this->translator->_('Add to date unit'),
+                'multiOptions' => $periodUnits
+            ]);
         } else {
-            $model->set('gro_valid_after_source',
-                    'label', $this->translator->_('Source'),
-                    'tableDisplay', 'small'
-                    );
-            $model->set('gro_valid_after_id', 'label', $this->translator->_('Round'),
-                    'multiOptions', $this->getRoundTranslations(),
-                    'tableDisplay', 'small'
-                    );
-            $model->setOnLoad('gro_valid_after_id', array($this, 'displayRoundId'));
-            $model->set('gro_valid_after_field',
-                    'label', $this->translator->_('Date calculation'),
-                    'tableHeaderDisplay', 'small'
-                    );
-            $model->setOnLoad('gro_valid_after_field', array($this, 'displayDateCalculation'));
-            $model->set('gro_valid_after_length');
-            $model->set('gro_valid_after_unit');
+            $metaModel->set('gro_valid_after_source', [
+                'label' => $this->translator->_('Source'),
+                'tableDisplay' => 'small'
+            ]);
+            $metaModel->set('gro_valid_after_id', [
+                'label' => $this->translator->_('Round'),
+                'multiOptions' => $this->getRoundTranslations(),
+                'tableDisplay' => 'small'
+            ]);
+            $metaModel->setOnLoad('gro_valid_after_id', [$this, 'displayRoundId']);
+            $metaModel->set('gro_valid_after_field', [
+                'label' => $this->translator->_('Date calculation'),
+                'tableHeaderDisplay' => 'small',
+            ]);
+            $metaModel->setOnLoad('gro_valid_after_field', [$this, 'displayDateCalculation']);
+            $metaModel->set('gro_valid_after_length');
+            $metaModel->set('gro_valid_after_unit');
         }
 
         if ($detailed) {
             // Calculate valid until
             $html = \Zalt\Html\Html::create()->h4($this->translator->_('Valid for calculation'));
-            $model->set('valid_for',
-                    'label', ' ',
-                    'default', $html,
-                    'elementClass', 'html',
-                    'value', $html
-                    );
+            $metaModel->set('valid_for', [
+                'label' => ' ',
+                'default' => $html,
+                'elementClass' => 'html',
+                'value' => $html
+            ]);
         }
 
-        $model->set('gro_valid_for_source',
-                'label', $this->translator->_('Date source'),
-                'default', self::TOKEN_TABLE,
-                'elementClass', 'Radio',
-                'escape', false,
-                'required', true,
-                'autoSubmit', true,
-                'multiOptions', $this->getSourceList(false, false, false)
-                );
-        $model->set('gro_valid_for_id',
-                'label', $this->translator->_('Round used'),
-                'default', '',
-                'autoSubmit', true,
-                );
+        $metaModel->set('gro_valid_for_source', [
+            'label' => $this->translator->_('Date source'),
+            'default' => self::TOKEN_TABLE,
+            'elementClass' => 'Radio',
+            'escape' => false,
+            'required' => true,
+            'autoSubmit' => true,
+            'multiOptions' => $this->getSourceList(false, false, false)
+        ]);
+        $metaModel->set('gro_valid_for_id', [
+            'label' => $this->translator->_('Round used'),
+            'default' => '',
+            'autoSubmit' => true,
+        ]);
 
         if ($detailed) {
-            $model->set('gro_valid_for_field',
-                    'label', $this->translator->_('Date used'),
-                    'default', 'gto_valid_from',
-                    'autoSubmit', true,
-                    );
-            $model->set('gro_valid_for_length',
-                    'label', $this->translator->_('Add to date'),
-                    'description', $this->translator->_('Can be negative'),
-                    'required', false,
-                    'default', 2,
-                    'filter', Digits::class
-                    );
-            $model->set('gro_valid_for_unit',
-                    'label', $this->translator->_('Add to date unit'),
-                    'multiOptions', $periodUnits
-                    );
+            $metaModel->set('gro_valid_for_field', [
+                'label' => $this->translator->_('Date used'),
+                'default' => 'gto_valid_from',
+                'autoSubmit' => true,
+            ]);
+            $metaModel->set('gro_valid_for_length', [
+                'label' => $this->translator->_('Add to date'),
+                'description' => $this->translator->_('Can be negative'),
+                'required' => false,
+                'default' => 2,
+                'filter' => new NumberFormat(),
+                'validator' => new IsInt()
+            ]);
+            $metaModel->set('gro_valid_for_unit', [
+                'label' => $this->translator->_('Add to date unit'),
+                'multiOptions' => $periodUnits
+            ]);
 
             // Calculate valid until
             $html = \Zalt\Html\Html::create()->h4($this->translator->_('Validity calculation'));
-            $model->set('valid_cond',
-                        'label', ' ',
-                        'default', $html,
-                        'elementClass', 'html',
-                        'value', $html
-            );
+            $metaModel->set('valid_cond', [
+                'label' => ' ',
+                'default' => $html,
+                'elementClass' => 'html',
+                'value' => $html
+            ]);
 
             // Continue with last round level items
-            $model->set('gro_condition');
-            $model->set('condition_display');
-            $model->set('gro_active');
-            $model->set('gro_changed_event');
+            $metaModel->set('gro_condition');
+            $metaModel->set('condition_display');
+            $metaModel->set('gro_active');
+            $metaModel->set('gro_changed_event');
         } else {
-            $model->set('gro_valid_for_source',
-                    'label', $this->translator->_('Source'),
-                    'tableDisplay', 'small'
-                    );
-            $model->set('gro_valid_for_id',
-                    'label', $this->translator->_('Round'),
-                    'multiOptions', $this->getRoundTranslations(),
-                    'tableDisplay', 'small'
-                    );
-            $model->setOnLoad('gro_valid_for_id', array($this, 'displayRoundId'));
-            $model->set('gro_valid_for_field',
-                    'label', $this->translator->_('Date calculation'),
-                    'tableHeaderDisplay', 'small'
-                    );
-            $model->setOnLoad('gro_valid_for_field', array($this, 'displayDateCalculation'));
-            $model->set('gro_valid_for_length');
-            $model->set('gro_valid_for_unit');
+            $metaModel->set('gro_valid_for_source', [
+                'label' => $this->translator->_('Source'),
+                'tableDisplay' => 'small'
+            ]);
+            $metaModel->set('gro_valid_for_id', [
+                'label' => $this->translator->_('Round'),
+                'multiOptions' => $this->getRoundTranslations(),
+                'tableDisplay' => 'small'
+            ]);
+            $metaModel->setOnLoad('gro_valid_for_id', [$this, 'displayRoundId']);
+            $metaModel->set('gro_valid_for_field', [
+                'label' => $this->translator->_('Date calculation'),
+                'tableHeaderDisplay' => 'small'
+            ]);
+            $metaModel->setOnLoad('gro_valid_for_field', [$this, 'displayDateCalculation']);
+            $metaModel->set('gro_valid_for_length');
+            $metaModel->set('gro_valid_for_unit');
         }
 
         return $model;

--- a/src/Tracker/Model/RoundModel.php
+++ b/src/Tracker/Model/RoundModel.php
@@ -59,15 +59,15 @@ class RoundModel extends GemsJoinModel
                 if (isset($row['gro_id_round'])) {
                     $roundId = $row['gro_id_round'];
                     if ($this->isDeleteable($roundId)) {
-                        $this->resultFetcher->deleteFromTable(
-                            'gems__rounds',
-                            (new Where())->equalTo('gro_id_round', $roundId)
-                        );
-
                         // Delete the round before anyone starts using it
                         $this->resultFetcher->deleteFromTable(
                             'gems__tokens',
                             (new Where())->equalTo('gto_id_round', $roundId)
+                        );
+
+                        $this->resultFetcher->deleteFromTable(
+                            'gems__rounds',
+                            (new Where())->equalTo('gro_id_round', $roundId)
                         );
                     } else {
                         $values['gro_id_round'] = $roundId;

--- a/src/Tracker/Model/RoundModel.php
+++ b/src/Tracker/Model/RoundModel.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  *
  * @package    Gems
@@ -11,7 +13,12 @@
 
 namespace Gems\Tracker\Model;
 
-use Gems\Model\JoinModel;
+use Gems\Db\ResultFetcher;
+use Gems\Model\GemsJoinModel;
+use Gems\Model\MetaModelLoader;
+use Laminas\Db\Sql\Where;
+use Zalt\Base\TranslatorInterface;
+use Zalt\Model\Sql\SqlRunnerInterface;
 
 /**
  *
@@ -22,45 +29,46 @@ use Gems\Model\JoinModel;
  * @license    New BSD License
  * @since      Class available since version 1.7.1 21-apr-2015 13:43:07
  */
-class RoundModel extends JoinModel
+class RoundModel extends GemsJoinModel
 {
-    /**
-     *
-     * @var \Zend_Db_Adapter_Abstract
-     */
-    protected $db;
+    public function __construct(
+        MetaModelLoader $metaModelLoader,
+        SqlRunnerInterface $sqlRunner,
+        TranslatorInterface $translate,
+        protected readonly ResultFetcher $resultFetcher,
+    ) {
+        parent::__construct('gems__rounds', $metaModelLoader, $sqlRunner, $translate);
 
-    /**
-     * Construct a round model
-     */
-    public function __construct()
-    {
-        parent::__construct('rounds', 'gems__rounds', 'gro', true);
-
-        $this->db = $this->getAdapter();
+        $metaModelLoader->setChangeFields($this->metaModel, 'gro');
     }
 
     /**
      * Delete items from the model
      *
      * @param mixed $filter True to use the stored filter, array to specify a different filter
-     * @param array $saveTables Array of table names => save mode
+     * @param array|null $saveTables Array of table names => save mode
      * @return int The number of items deleted
      */
     public function delete($filter = null, array $saveTables = null): int
     {
-        $this->trackUsage();
-        $rows = $this->load($filter);
+        $this->metaModel->trackUsage();
+        $rows = $this->load($filter, null, ['gro_id_round', 'gro_active']);
 
         if ($rows) {
             foreach ($rows as $row) {
                 if (isset($row['gro_id_round'])) {
                     $roundId = $row['gro_id_round'];
                     if ($this->isDeleteable($roundId)) {
-                        $this->db->delete('gems__rounds', $this->db->quoteInto('gro_id_round = ?', $roundId));
+                        $this->resultFetcher->deleteFromTable(
+                            'gems__rounds',
+                            (new Where())->equalTo('gro_id_round', $roundId)
+                        );
 
                         // Delete the round before anyone starts using it
-                        $this->db->delete('gems__tokens', $this->db->quoteInto('gto_id_round = ?', $roundId));
+                        $this->resultFetcher->deleteFromTable(
+                            'gems__tokens',
+                            (new Where())->equalTo('gto_id_round', $roundId)
+                        );
                     } else {
                         $values['gro_id_round'] = $roundId;
                         $values['gro_active']   = 0;
@@ -71,6 +79,25 @@ class RoundModel extends JoinModel
             }
         }
         return $this->getChanged();
+    }
+
+    public function setDefaultTrackId(int $trackId): void
+    {
+        $this->metaModel->set('gro_id_track', ['default' => $trackId]);
+    }
+
+    public function setDefaultOrder(int $trackId): void
+    {
+        $newOrder = $this->resultFetcher->fetchOne(
+            "SELECT MAX(gro_id_order) FROM gems__rounds WHERE gro_id_track = ?",
+            [$trackId]
+        );
+
+        if ($newOrder) {
+            $this->metaModel->set('gro_id_order', ['default' => $newOrder + 10]);
+        } else {
+            $this->metaModel->set('gro_valid_after_source', ['default' => 'rtr']);
+        }
     }
 
     /**
@@ -90,9 +117,9 @@ class RoundModel extends JoinModel
                         (gro_valid_after_id = ? AND gro_valid_after_source IN ('tok', 'ans')) OR 
                         (gro_valid_for_id = ? AND gro_valid_for_source IN ('tok', 'ans'))
                         )";
-        return $this->db->fetchOne($sql, [$roundId, $roundId, $roundId]);
+        return $this->resultFetcher->fetchOne($sql, [$roundId, $roundId, $roundId]);
     }
-    
+
     /**
      * Get the number of times someone started answering this round.
      *
@@ -106,16 +133,15 @@ class RoundModel extends JoinModel
         }
 
         $sql = "SELECT COUNT(*) FROM gems__tokens WHERE gto_id_round = ? AND gto_start_time IS NOT NULL";
-        return $this->db->fetchOne($sql, [$roundId]);
+        return $this->resultFetcher->fetchOne($sql, [$roundId]);
     }
-    
+
     /**
      * Can this round be deleted as is?
      *
      * @param int $roundId
-     * @return boolean
      */
-    public function isDeleteable($roundId)
+    public function isDeleteable($roundId): bool
     {
         if (! $roundId) {
             return true;

--- a/src/Tracker/Model/TrackModel.php
+++ b/src/Tracker/Model/TrackModel.php
@@ -208,9 +208,6 @@ class TrackModel extends SqlTableModel
                 if (isset($row['gtr_id_track'])) {
                     $trackId = $row['gtr_id_track'];
                     if ($this->isDeletable($trackId)) {
-
-                        $this->resultFetcher->query('DELETE FROM gems__tracks WHERE gtr_id_track = ?', [$trackId]);
-
                         // Now cascade to children, they should take care of further cascading
                         // Delete rounds
                         $trackEngine = $this->tracker->getTrackEngine($trackId);
@@ -223,6 +220,8 @@ class TrackModel extends SqlTableModel
 
                         // Delete assigned but unused tracks
                         $this->resultFetcher->query('DELETE FROM gems__respondent2track WHERE gr2t_id_track = ?', [$trackId]);
+
+                        $this->resultFetcher->query('DELETE FROM gems__tracks WHERE gtr_id_track = ?', [$trackId]);
                     } else {
                         $values['gtr_id_track'] = $trackId;
                         $values['gtr_active'] = 0;

--- a/src/Tracker/RespondentTrack.php
+++ b/src/Tracker/RespondentTrack.php
@@ -588,7 +588,7 @@ class RespondentTrack
             $this->maskRepository->disableMaskRepository();
             $this->refresh();
             if ($this->_respondentObject) {
-                $this->_respondentObject->refresh();;
+                $this->_respondentObject->refresh();
             }
         }
         // Execute any defined functions

--- a/src/Tracker/Snippets/ShowRoundSnippetAbstract.php
+++ b/src/Tracker/Snippets/ShowRoundSnippetAbstract.php
@@ -91,7 +91,7 @@ class ShowRoundSnippetAbstract extends ModelDetailTableSnippetAbstract
         protected RequestInfo $requestInfo,
         TranslatorInterface $translate,
         MessengerInterface $messenger,
-        protected RouteHelper $routeHelper, 
+        protected RouteHelper $routeHelper,
         protected Tracker $tracker)
     {
         // We're setting trait variables so no constructor promotion
@@ -100,11 +100,6 @@ class ShowRoundSnippetAbstract extends ModelDetailTableSnippetAbstract
         parent::__construct($snippetOptions, $this->requestInfo, $translate);
     }
 
-    /**
-     * Creates the model
-     *
-     * @return \MUtil\Model\ModelAbstract
-     */
     protected function createModel(): DataReaderInterface
     {
         return $this->trackEngine->getRoundModel(true, 'show');


### PR DESCRIPTION
Migrate RoundModel to be based of zalt-model insteadof MUtil.

Also included with this pull request:
- Fixes Track and Round deletion so that a track can be deleted when it is not used
- Adds `laminas/laminas-i18n` in order to be able to properly validate (and format) integers. This is not possible with the laminas validator Digits [see also](https://docs.laminas.dev/laminas-validator/validators/digits/#validating-digits)
- Reverts the fix for #434 since it does not seem to be an issue anymore
- `gro_valid_after_length` and `gro_valid_for_length` are now required to reflect the table scheme
- Fixed Track and Round deletion so that no error will be thrown when deleting a Track or Round which has other tables referencing (with foreign key) said Track or Round