### PR TITLE
RespondentTrackHandler: Fix undelete action

### DIFF
--- a/src/Handlers/Respondent/RespondentTrackHandler.php
+++ b/src/Handlers/Respondent/RespondentTrackHandler.php
@@ -421,12 +421,8 @@ class RespondentTrackHandler extends RespondentChildHandlerAbstract
      */
     public function undeleteAction()
     {
-        if ($this->deleteSnippets) {
-            $this->deleteParameters['requestUndelete'] = true;
+        $this->deleteParameters['requestUndelete'] = true;
 
-            $params = $this->_processParameters($this->deleteParameters);
-
-            $this->addSnippets($this->deleteSnippets, $params);
-        }
+        parent::deleteAction();
     }
 }


### PR DESCRIPTION
The undelete action did not work, you'd get a form expiration message. Fix that. We can just use the parent class to do most of the work, and the if() statement is not necessary, as it is already present in the ModelSnippetLegacyHandlerAbstract class.