### PR TITLE
Update search filter to include data from all accessible organizations

### DIFF
--- a/src/Model/Transform/OrganizationAccessTransformer.php
+++ b/src/Model/Transform/OrganizationAccessTransformer.php
@@ -10,20 +10,21 @@ class OrganizationAccessTransformer extends ModelTransformerAbstract
 {
     public function __construct(
         protected readonly OrganizationRepository $organizationRepository,
+        protected readonly string $organizationField,
     ) {
     }
 
     public function transformFilter(MetaModelInterface $model, array $filter): array
     {
         // If there is no organization filter at all, we can't filter on multiple organizations.
-        if (!isset($filter['gr2t_id_organization'])) {
+        if (!isset($filter[$this->organizationField])) {
             return $filter;
         }
         // If we're already filtering on multiple organizations, don't change that.
-        if (is_array($filter['gr2t_id_organization'])) {
+        if (is_array($filter[$this->organizationField])) {
             return $filter;
         }
-        $filter['gr2t_id_organization'] = array_keys($this->organizationRepository->getAllowedOrganizationsFor($filter['gr2t_id_organization']));
+        $filter[$this->organizationField] = array_keys($this->organizationRepository->getAllowedOrganizationsFor($filter[$this->organizationField]));
         return $filter;
     }
 }

--- a/src/Model/Transform/OrganizationAccessTransformer.php
+++ b/src/Model/Transform/OrganizationAccessTransformer.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Gems\Model\Transform;
+
+use Gems\Repository\OrganizationRepository;
+use Zalt\Model\MetaModelInterface;
+use Zalt\Model\Transform\ModelTransformerAbstract;
+
+class OrganizationAccessTransformer extends ModelTransformerAbstract
+{
+    public function __construct(
+        protected readonly OrganizationRepository $organizationRepository,
+    ) {
+    }
+
+    public function transformFilter(MetaModelInterface $model, array $filter): array
+    {
+        // If there is no organization filter at all, we can't filter on multiple organizations.
+        if (!isset($filter['gr2t_id_organization'])) {
+            return $filter;
+        }
+        // If we're already filtering on multiple organizations, don't change that.
+        if (is_array($filter['gr2t_id_organization'])) {
+            return $filter;
+        }
+        $filter['gr2t_id_organization'] = array_keys($this->organizationRepository->getAllowedOrganizationsFor($filter['gr2t_id_organization']));
+        return $filter;
+    }
+}

--- a/src/Tracker/Model/RespondentTrackModel.php
+++ b/src/Tracker/Model/RespondentTrackModel.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Gems\Tracker\Model;
 
-use DateTime;
 use DateTimeImmutable;
 use DateTimeInterface;
 use Gems\Db\ResultFetcher;
@@ -137,7 +136,7 @@ class RespondentTrackModel extends GemsMaskedModel
             'respondent_name'
         );
 
-        $this->metaModel->addTransformer(new OrganizationAccessTransformer($this->organizationRepository));
+        $this->metaModel->addTransformer(new OrganizationAccessTransformer($this->organizationRepository, 'gr2t_id_organization'));
     }
 
     /**
@@ -152,7 +151,7 @@ class RespondentTrackModel extends GemsMaskedModel
         $this->metaModel->setKeys([
             \Gems\Model::RESPONDENT_TRACK => 'gr2t_id_respondent_track',
             MetaModelInterface::REQUEST_ID1     => 'gr2o_patient_nr',
-            MetaModelInterface::REQUEST_ID2 => 'gr2o_id_organization',
+            MetaModelInterface::REQUEST_ID2 => 'gr2t_id_organization',
         ]);
 
         $this->metaModel->set('gtr_track_name', ['label' => $this->_('Track')]);

--- a/src/Tracker/Model/RespondentTrackModel.php
+++ b/src/Tracker/Model/RespondentTrackModel.php
@@ -13,19 +13,21 @@ declare(strict_types=1);
 
 namespace Gems\Tracker\Model;
 
+use DateTime;
+use DateTimeImmutable;
+use DateTimeInterface;
 use Gems\Db\ResultFetcher;
+use Gems\Legacy\CurrentUserRepository;
 use Gems\Model as GemsModel;
 use Gems\Model\GemsMaskedModel;
 use Gems\Model\MetaModelLoader;
+use Gems\Model\Transform\OrganizationAccessTransformer;
 use Gems\Repository\MailRepository;
+use Gems\Repository\OrganizationRepository;
 use Gems\Tracker\Engine\TrackEngineInterface;
 use Gems\User\Mask\MaskRepository;
 use Gems\Util\Translated;
 use MUtil\Model;
-use DateTime;
-use DateTimeImmutable;
-use DateTimeInterface;
-use Gems\Legacy\CurrentUserRepository;
 use Zalt\Base\TranslatorInterface;
 use Zalt\Model\MetaModelInterface;
 use Zalt\Model\Sql\SqlRunnerInterface;
@@ -71,6 +73,7 @@ class RespondentTrackModel extends GemsMaskedModel
         protected readonly Translated $translatedUtil,
         protected readonly CurrentUserRepository $currentUserRepository,
         protected readonly MailRepository $mailRepository,
+        protected readonly OrganizationRepository $organizationRepository,
     ) {
         parent::__construct(
             'gems__respondent2track',
@@ -133,6 +136,8 @@ class RespondentTrackModel extends GemsMaskedModel
             "CONCAT(COALESCE(CONCAT(grs_last_name, ', '), '-, '), COALESCE(CONCAT(grs_first_name, ' '), ''), COALESCE(grs_surname_prefix, ''))",
             'respondent_name'
         );
+
+        $this->metaModel->addTransformer(new OrganizationAccessTransformer($this->organizationRepository));
     }
 
     /**


### PR DESCRIPTION
This does two things: on the tracks page it lists all tracks available to the current organization or to an organization where the current organization has access to.
It also ensures that a track that exists for an accessible organization is visible from the context of the current organizations.

There's still some work to do though:
  - Showing a track of an accessible organization switches the context to that of the accessible organization (e.g. the organization parameter in the URL is not the current, but the accessable org)
  - Editing a track of an accessible organization from the context of the current organization changes the value of gr2t_id_organization for that track to the current org, effectively moving it, which is not what we want.