### PR TITLE
ChangePasswordHandler: Don't skip reporting of maxAge rule

### DIFF
--- a/src/Handlers/Auth/ChangePasswordHandler.php
+++ b/src/Handlers/Auth/ChangePasswordHandler.php
@@ -62,7 +62,7 @@ class ChangePasswordHandler implements RequestHandlerInterface
         if ($request->getMethod() !== 'POST') {
             $data = [
                 'ask_old' => true,
-                'rules' => $this->passwordChecker->reportPasswordWeakness($user, null, true),
+                'rules' => $this->passwordChecker->reportPasswordWeakness($user, null, false),
                 'validationMessenger' => $this->validationMessenger,
             ];
 


### PR DESCRIPTION
When changing a password, there's no reason not to tell a user after how many days his password will need to be changed again.