### PR TITLE
Add a new command to clear the autoconfig cache

### DIFF
--- a/src/Command/ClearAutoConfiguratorCache.php
+++ b/src/Command/ClearAutoConfiguratorCache.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Gems\Command;
+
+use Gems\Config\AutoConfigurator;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(name: 'app:clear-autoconfig-cache', description: 'Clears the autoconfigurator cache')]
+class ClearAutoConfiguratorCache extends Command
+{
+
+    public function __construct(
+        protected readonly AutoConfigurator $autoConfigurator,
+    ) {
+        parent::__construct();
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $autoconfigCachefile = $this->autoConfigurator->getAutoconfigFilename();
+        if (is_null($autoconfigCachefile)) {
+            $output->writeln("<comment>Autoconfig filename not configured</comment>");
+            return static::FAILURE;
+        }
+        if ($this->autoConfigurator->clearAutoConfigConfig()) {
+            $output->writeln("<info>Config cache at '$autoconfigCachefile' has been cleared</info>");
+            return static::SUCCESS;
+        } else {
+            $output->writeln("<comment>Config cache at '$autoconfigCachefile' was NOT cleared!</comment>");
+            return static::FAILURE;
+        }
+    }
+}

--- a/src/Config/AutoConfigurator.php
+++ b/src/Config/AutoConfigurator.php
@@ -102,9 +102,9 @@ class AutoConfigurator
         return $this->autoconfigConfig;
     }
 
-    protected function getAutoconfigFilename(): string
+    public function getAutoconfigFilename(): ?string
     {
-        return $this->config['autoconfig']['cache_path'];
+        return $this->config['autoconfig']['cache_path'] ?? null;
     }
 
     protected function getClassnameFromFile(SplFileInfo $file): ?string
@@ -253,5 +253,14 @@ class AutoConfigurator
     {
         $filename = $this->getAutoconfigFilename();
         file_put_contents($filename, '<?php return ' . var_export($this->autoconfigConfig, true) . ';');
+    }
+
+    public function clearAutoConfigConfig(): bool
+    {
+        $filename = $this->getAutoconfigFilename();
+        if ($filename && file_exists($filename)) {
+            return unlink($filename);
+        }
+        return false;
     }
 }


### PR DESCRIPTION
Since isFresh() returns true if the environment is not development, we need an external trigger to ensure the autoconfig is renewed after updates. Having a console command that simply clears the cache keeps things similar to what we already have.