### PR TITLE
Let all model exports work with db export

### DIFF
--- a/src/Export/Db/SingleModelContainer.php
+++ b/src/Export/Db/SingleModelContainer.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @package    Gems
+ * @subpackage Export\Db
+ * @author     Matijs de Jong <mjong@magnafacta.nl>
+ */
+
+namespace Gems\Export\Db;
+
+use Psr\Container\ContainerInterface;
+use Zalt\Model\MetaModellerInterface;
+
+/**
+ * @package    Gems
+ * @subpackage Export\Db
+ * @since      Class available since version 1.0
+ */
+class SingleModelContainer implements Containerinterface
+{
+    public function __construct(
+        protected readonly MetaModellerInterface $model,
+        protected readonly string $modelIdentifier,
+    )
+    { }
+
+
+    public function get(string $id, array $modelFilter = [], array $applyFunctions = []): MetaModellerInterface
+    {
+        if ($id !== $this->modelIdentifier) {
+            throw new \Exception("Id $id not found in " . __CLASS__ . ".");
+        }
+
+        foreach($applyFunctions as $applyFunction) {
+            if (method_exists($this->model, $applyFunction)) {
+                $this->model->$applyFunction();
+            }
+        }
+
+        return $this->model;
+    }
+
+    public function has(string $id): bool
+    {
+        return $id === $this->modelIdentifier;
+    }
+
+}

--- a/src/Handlers/GemsHandler.php
+++ b/src/Handlers/GemsHandler.php
@@ -327,7 +327,7 @@ abstract class GemsHandler extends \Zalt\SnippetsHandler\ModelSnippetHandlerAbst
             $action->pageNumber  = $this->getPageNumber();
 
             if ($action instanceof BrowseFilteredAction) {
-                $useSessionReadonly = $action instanceof ExportAction || $action instanceof ImportAction;
+                $useSessionReadonly   = $action instanceof ExportAction || $action instanceof ImportAction;
                 $action->searchFilter = $this->getSearchFilter($useSessionReadonly);
 
                 if ($action instanceof BrowseSearchAction) {
@@ -337,13 +337,17 @@ abstract class GemsHandler extends \Zalt\SnippetsHandler\ModelSnippetHandlerAbst
                 if ($action instanceof ExportAction) {
                     $action->csrfName = $this->getCsrfTokenName();
                     $action->csrfToken = $this->getCsrfToken($action->csrfName);
+                    $action->formTitle = \ucfirst(sprintf($this->_('%s export'), $this->getTopic(1)));
+                    $action->ignoreFilterForDownload = true;
+                    $action->modelIdentifier = get_class($this);
+                    $action->setSingleModel($action->model);
+
                     $step = $this->requestInfo->getParam('step');
                     if ($step) {
                         if (ExportAction::STEP_RESET !== $step) {
                             $action->step = $step;
                         }
                     }
-                    $action->formTitle = \ucfirst(sprintf($this->_('%s export'), $this->getTopic(1)));
                 }
             }
 

--- a/src/Handlers/ModelSnippetLegacyHandlerAbstract.php
+++ b/src/Handlers/ModelSnippetLegacyHandlerAbstract.php
@@ -381,18 +381,21 @@ abstract class ModelSnippetLegacyHandlerAbstract extends \MUtil\Handler\ModelSni
                     $action->textSearchField = $params['textSearchField'];
                 }
                 $action->searchFilter = $this->getSearchFilter(false);
-            }
-        }
 
-        if ($action instanceof ExportAction) {
-            $action->csrfName = $this->getCsrfTokenName();
-            $action->csrfToken = $this->getCsrfToken($action->csrfName);
-            $action->formTitle = \ucfirst(sprintf($this->_('%s export'), $this->getTopic(1)));
+                if ($action instanceof ExportAction) {
+                    $action->csrfName = $this->getCsrfTokenName();
+                    $action->csrfToken = $this->getCsrfToken($action->csrfName);
+                    $action->formTitle = \ucfirst(sprintf($this->_('%s export'), $this->getTopic(1)));
+                    $action->ignoreFilterForDownload = true;
+                    $action->modelIdentifier = get_class($this);
+                    $action->setSingleModel($action->model);
 
-            $step = $this->requestInfo->getParam('step');
-            if ($step) {
-                if (ExportAction::STEP_RESET !== $step) {
-                    $action->step = $step;
+                    $step = $this->requestInfo->getParam('step');
+                    if ($step) {
+                        if (ExportAction::STEP_RESET !== $step) {
+                            $action->step = $step;
+                        }
+                    }
                 }
             }
         }

--- a/src/Snippets/Export/ExportDownloadSnippet.php
+++ b/src/Snippets/Export/ExportDownloadSnippet.php
@@ -23,6 +23,7 @@ use Zalt\Base\RequestInfo;
 use Zalt\Base\TranslatorInterface;
 use Zalt\Message\MessageTrait;
 use Zalt\Model\Data\DataReaderInterface;
+use Zalt\Model\MetaModelInterface;
 use Zalt\Snippets\ModelBridge\TableBridge;
 use Zalt\SnippetsLoader\SnippetOptions;
 
@@ -40,6 +41,8 @@ class ExportDownloadSnippet extends ModelTableSnippet
     use MessageTrait;
 
     protected int $currentUserId;
+
+    protected bool $ignoreFilterForDownload = false;
 
     protected array $menuEditRoutes = ['delete'];
 
@@ -59,6 +62,11 @@ class ExportDownloadSnippet extends ModelTableSnippet
     ) {
         parent::__construct($snippetOptions, $requestInfo, $menuHelper, $translate);
         $this->currentUserId = $currentUserRepository->getCurrentUserId();
+        if ($this->ignoreFilterForDownload) {
+            $this->extraFilter = [];
+            $this->searchData = [];
+            $this->textSearchField = '';
+        }
     }
 
     protected function createModel(): DataReaderInterface

--- a/src/SnippetsActions/Export/ExportAction.php
+++ b/src/SnippetsActions/Export/ExportAction.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace Gems\SnippetsActions\Export;
 
+use Gems\Export\Db\SingleModelContainer;
 use Gems\Snippets\Export\ExportBatchSnippet;
 use Gems\Snippets\Export\ExportDownloadStepSnippet;
 use Gems\Snippets\Export\ExportFormSnippet;
@@ -17,6 +18,7 @@ use Gems\SnippetsActions\Browse\BrowseFilteredAction;
 use Gems\SnippetsActions\ButtonRowActiontrait;
 use Gems\Task\ExportRunnerBatch;
 use Psr\Container\ContainerInterface;
+use Zalt\Model\MetaModellerInterface;
 
 /**
  * @package    Gems
@@ -44,7 +46,7 @@ class ExportAction extends BrowseFilteredAction
     /**
      * @var ExportRunnerBatch Set in ExportFormSnippet->hasHtmlOutput()
      */
-    public ExportRunnerBatch $batch;
+    public ?ExportRunnerBatch $batch;
 
     /**
      * Field name for crsf protection field.
@@ -62,6 +64,11 @@ class ExportAction extends BrowseFilteredAction
 
     public string $formTitle = '';
 
+    /**
+     * @var bool Ignore the filter (for export download snippet)
+     */
+    public bool $ignoreFilterForDownload = false;
+
     public array $modelApplyFunctions = [];
 
     public ContainerInterface|null $modelContainer = null;
@@ -73,4 +80,14 @@ class ExportAction extends BrowseFilteredAction
     public bool $sensitiveData = true;
 
     public string $step = self::STEP_FORM;
+
+    public function setSingleModel(MetaModellerInterface $model): self
+    {
+        if (! $this->modelIdentifier) {
+            $this->modelIdentifier = $model->getName();
+        }
+
+        $this->modelContainer = new SingleModelContainer($model, $this->modelIdentifier);
+        return $this;
+    }
 }


### PR DESCRIPTION
Let the standard model handlers use the db export mechanism.

The most tricky part was having the download snippet not use the filter of the handler