### PR TITLE
Fix export of surveys with long names

### DIFF
--- a/src/Config/Db/Patches/Upgrade2x/GemsExportIdLengthPatch.php
+++ b/src/Config/Db/Patches/Upgrade2x/GemsExportIdLengthPatch.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gems\Config\Db\Patches\Upgrade2x;
+
+use Gems\Db\Migration\PatchAbstract;
+
+class GemsExportIdLengthPatch extends PatchAbstract
+{
+    public function getDescription(): string|null
+    {
+        return 'Lengthen gems__file_exports gfex_export_id field to 100 characters';
+    }
+
+    public function getOrder(): int
+    {
+        return 20251407125616;
+    }
+
+    public function up(): array
+    {
+        return ["ALTER TABLE gems__file_exports CHANGE gfex_export_id gfex_export_id varchar(100) CHARACTER SET 'utf8mb4' COLLATE 'utf8mb4_unicode_ci' NOT NULL"];
+    }
+
+    public function down(): ?array
+    {
+        return ["ALTER TABLE gems__file_exports CHANGE gfex_export_id gfex_export_id varchar(64) CHARACTER SET 'utf8mb4' COLLATE 'utf8mb4_unicode_ci' NOT NULL"];
+    }
+}

--- a/src/Task/Export/InitDbExport.php
+++ b/src/Task/Export/InitDbExport.php
@@ -34,7 +34,7 @@ class InitDbExport extends TaskAbstract
         $modelContainer = $batch->getVariable('modelContainer');
         $model = $modelContainer->get($modelIdentifier, $searchFilter, $modelApplyFunctions);
 
-        $exportId = $model->getName() . (new \DateTimeImmutable())->format('YmdHis');
+        $exportId = hash('sha256', $model->getName()) . '-' . (new \DateTimeImmutable())->format('YmdHis');
 
         $currentExportIds = $batch->getVariable('exportIds') ?? [];
         if (!in_array($exportId, $currentExportIds)) {


### PR DESCRIPTION
It was not possible to export surveys with names longer than 50 characters. This fixes that.

Fixes: CPRSD-115