### PR TITLE
Track field calculation and inactive appointments

### DIFF
--- a/src/Tracker/Field/AppointmentDerivedFieldAbstract.php
+++ b/src/Tracker/Field/AppointmentDerivedFieldAbstract.php
@@ -107,8 +107,10 @@ abstract class AppointmentDerivedFieldAbstract extends FieldAbstract
             foreach (array_filter($calcUsing) as $value) {
                 $appointment = $this->agenda->getAppointment($value);
 
-                if ($appointment->exists) {
+                if ($appointment->exists && $appointment->isActive()) {
                     return $this->getId($appointment);
+                } else {
+                    $currentValue = null;
                 }
             }
         }

--- a/src/Tracker/Field/DateField.php
+++ b/src/Tracker/Field/DateField.php
@@ -130,7 +130,13 @@ class DateField extends FieldAbstract
                 $appointment = $this->agenda->getAppointment($value);
 
                 if ($appointment->exists) {
-                    return $appointment->getAdmissionTime();
+                    if ($appointment->isActive()) {
+                        return $appointment->getAdmissionTime();
+                    } else {
+                        // Empty the Date field if there are appointments, but these
+                        // are not active
+                        $currentValue = null;
+                    }
                 }
             }
         }


### PR DESCRIPTION
This ensures that an inactive appointment is not used for track field calculation. With these changes, after canceling an appointment, the treatment date and caregiver fields are set to null (if no other active appointments exist).

I'm not entirely sure if there aren't any fields where we do want to take values from inactive appointments into account.