### PR TITLE
Calculate date from start of the week

### DIFF
--- a/src/Selector/DateSelectorAbstract.php
+++ b/src/Selector/DateSelectorAbstract.php
@@ -200,7 +200,7 @@ abstract class DateSelectorAbstract
                 if ($intervalInt < 0) {
                     $interval->invert = 1;
                 }
-                $date = $date->setTime(0, 0, 0)->modify('this monday')
+                $date = $date->setTime(0, 0, 0)->modify('monday this week')
                     ->add($interval);
                 $lAdd = new DateInterval('P7D');
                 $lSub = new DateInterval('PT1S');


### PR DESCRIPTION
When looking through this code I found an inconsistency. When calculating the month or year intervals, the code starts at the beginning of the interval (e.g. "first day of this month", "first day of January this year"). However, for the week interval it used "this monday", which translates to 'the first upcoming monday' on my system.

So I think this maybe needs to be "monday this week" to get the same behaviour?