### PR TITLE
Get date from appointment

### DIFF
--- a/src/Tracker/RespondentTrack.php
+++ b/src/Tracker/RespondentTrack.php
@@ -790,6 +790,8 @@ class RespondentTrack
      */
     public function getDate(string $fieldName): ?DateTimeInterface
     {
+        $date = false;
+
         if (isset($this->_respTrackData[$fieldName])) {
             $date = $this->_respTrackData[$fieldName];
         } else {
@@ -797,17 +799,17 @@ class RespondentTrack
 
             if (isset($this->_fieldData[$fieldName])) {
                 $date = $this->_fieldData[$fieldName];
+            }
+        }
 
-                if ($this->getTrackEngine()->isAppointmentField($fieldName)) {
-                    $appointment = $this->agenda->getAppointment($date);
-                    if ($appointment->isActive()) {
-                        $date = $appointment->getAdmissionTime();
-                    } else {
-                        $date = false;
-                    }
+        if ($this->getTrackEngine()->isAppointmentField($fieldName)) {
+            $appointmentId = $date;
+            $date = false;
+            if ($appointmentId && is_int($appointmentId)) {
+                $appointment = $this->agenda->getAppointment($appointmentId);
+                if ($appointment->isActive()) {
+                    $date = $appointment->getAdmissionTime();
                 }
-            } else {
-                $date = false;
             }
         }
 


### PR DESCRIPTION
This fixes a problem where the getDate() function would return a date based on the appointment Id instead of on the appointment date. If the field was already set in the _respTrackData array, it would not be used to look up the appointment date.