### PR TITLE
Feature/pick from date appointment field

### DIFF
--- a/configs/db/tables/gems__track_appointments.100.sql
+++ b/configs/db/tables/gems__track_appointments.100.sql
@@ -15,6 +15,8 @@ CREATE TABLE if not exists gems__track_appointments (
         gtap_readonly           boolean not null default false,
 
         gtap_filter_id          bigint unsigned null references gems__appointment_filters (gaf_id),
+        gtap_diff_target_field  varchar(20) CHARACTER SET 'utf8mb4' COLLATE 'utf8mb4_unicode_ci' null,
+
         -- deprecated
         gtap_after_next         boolean not null default 1,
         -- deprecated

--- a/src/Agenda/Agenda.php
+++ b/src/Agenda/Agenda.php
@@ -483,7 +483,7 @@ class Agenda
         return $this->overloader->create('Agenda\\EpisodeOfCare', $episodeData);
     }
 
-    public function getEpisodeOfCareData(int $episodeId): array
+    public function getEpisodeOfCareData(int $episodeId): array|null
     {
         $select = $this->resultFetcher->getSelect('gems__episodes_of_care');
         $select->where(['gec_episode_of_care_id' => $episodeId]);

--- a/src/Agenda/Appointment.php
+++ b/src/Agenda/Appointment.php
@@ -33,28 +33,20 @@ use Zalt\Base\TranslatorInterface;
 class Appointment
 {
     /**
-     *
      * @var int The id of the appointment
      */
     protected int $id;
 
     /**
-     *
      * @var array The gems appointment data
      */
     protected array $data = [];
 
     /**
      * True when the token does exist.
-     *
-     * @var boolean
      */
     public bool $exists = true;
 
-    /**
-     *
-     * @var FilterTracer
-     */
     protected FilterTracer|null $filterTracer = null;
 
     /**
@@ -77,9 +69,7 @@ class Appointment
     }
 
     /**
-     * Return the description of the current ativity
-     *
-     * @return string or null when not found
+     * @return string|null description of the current activity or null when not found
      */
     public function getActivityDescription(): string|null
     {
@@ -93,9 +83,7 @@ class Appointment
     }
 
     /**
-     * Return the id of the current activity
-     *
-     * @return int
+     * @return int|null current activity ID
      */
     public function getActivityId(): int|null
     {
@@ -103,9 +91,7 @@ class Appointment
     }
 
     /**
-     * Return the admission time
-     *
-     * @return ?DateTimeInterface Admission time as a date or null
+     * @return DateTimeInterface|null Admission time as a date or null
      */
     public function getAdmissionTime(): DateTimeInterface|null
     {
@@ -121,9 +107,7 @@ class Appointment
     }
 
     /**
-     * Get the DB id of the attending by person
-     *
-     * @return int
+     * @return int|null DB id of the attending by person
      */
     public function getAttendedById(): int|null
     {
@@ -131,9 +115,7 @@ class Appointment
     }
 
     /**
-     * The cooment to the appointment
-     *
-     * @return string
+     * @return string The comment to the appointment
      */
     public function getComment(): string
     {
@@ -144,8 +126,6 @@ class Appointment
      * Get a general description of this appointment
      *
      * @see \Gems\Agenda->getAppointmentDisplay()
-     *
-     * @return string
      */
     public function getDisplayString(): string
     {
@@ -158,10 +138,6 @@ class Appointment
         return implode($this->translator->_('; '), array_filter($results));
     }
 
-    /**
-     *
-     * @return EpisodeOfCare|null
-     */
     public function getEpisode(): EpisodeOfCare|null
     {
         $episodeId = $this->getEpisodeId();
@@ -173,19 +149,13 @@ class Appointment
         return null;
     }
 
-    /**
-     *
-     * @return int
-     */
     public function getEpisodeId(): int|null
     {
         return $this->data['gap_id_episode'];
     }
 
     /**
-     * Return the appointment id
-     *
-     * @return int
+     * @return int appointment id
      */
     public function getId(): int
     {
@@ -193,9 +163,7 @@ class Appointment
     }
 
     /**
-     * Return the appointment info array
-     *
-     * @return array
+     * @return array appointment info array
      */
     public function getInfo(): array
     {
@@ -211,9 +179,7 @@ class Appointment
     }
 
     /**
-     * Return the description of the current location
-     *
-     * @return string or null when not found
+     * @return string|null Return the description of the current location or null when not found
      */
     public function getLocationDescription(): string|null
     {
@@ -227,27 +193,20 @@ class Appointment
     }
 
     /**
-     * Get the DB id of the location
-     *
-     * @return int
+     * @return int DB id of the location
      */
     public function getLocationId(): int|null
     {
         return $this->data['gap_id_location'];
     }
 
-    /**
-     *
-     * @return int
-     */
     public function getOrganizationId(): int
     {
         return $this->data['gap_id_organization'];
     }
 
     /**
-     *
-     * @return string The respondents patient number
+     * @return string|null The respondents patient number
      */
     public function getPatientNumber(): string|null
     {
@@ -259,9 +218,7 @@ class Appointment
     }
 
     /**
-     * Return the description of the current procedure
-     *
-     * @return string|null or null when not found
+     * Return the description of the current procedure or null when not found
      */
     public function getProcedureDescription(): string|null
     {
@@ -276,8 +233,6 @@ class Appointment
 
     /**
      * Return the id of the current procedure
-     *
-     * @return int
      */
     public function getProcedureId(): int|null
     {
@@ -286,8 +241,6 @@ class Appointment
 
     /**
      * Get the DB id of the referred by person
-     *
-     * @return int
      */
     public function getReferredById(): int|null
     {
@@ -296,8 +249,6 @@ class Appointment
 
     /**
      * Return the respondent object
-     *
-     * @return \Gems\Tracker\Respondent
      */
     public function getRespondent(): Respondent
     {
@@ -310,8 +261,6 @@ class Appointment
 
     /**
      * Return the user / respondent id
-     *
-     * @return int
      */
     public function getRespondentId(): int
     {
@@ -320,8 +269,6 @@ class Appointment
 
     /**
      * The source of the appointment
-     *
-     * @return string
      */
     public function getSource(): string
     {
@@ -330,8 +277,6 @@ class Appointment
 
     /**
      * The source id of the appointment
-     *
-     * @return string
      */
     public function getSourceId(): string|int
     {

--- a/src/Config/Db/Patches/Upgrade2x/AddDiffTargetFieldToTrackAppointments.php
+++ b/src/Config/Db/Patches/Upgrade2x/AddDiffTargetFieldToTrackAppointments.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Gems\Config\Db\Patches\Upgrade2x;
+
+use Gems\Db\Migration\PatchAbstract;
+
+class AddDiffTargetFieldToTrackAppointments extends PatchAbstract
+{
+    public function getDescription(): string|null
+    {
+        return 'Add diff target field to track appointments';
+    }
+
+    public function getOrder(): int
+    {
+        return 20250917100000;
+    }
+
+    public function up(): array
+    {
+        return [
+            'ALTER TABLE gems__track_appointments ADD COLUMN gtap_diff_target_field varchar(20) null AFTER gtap_filter_id',
+        ];
+    }
+
+    public function down(): array
+    {
+        return [
+            'ÁLTER TABLE gems__track_appointments DROP COLUMN gtap_diff_target_field',
+        ];
+    }
+}

--- a/src/Tracker/Field/AppointmentField.php
+++ b/src/Tracker/Field/AppointmentField.php
@@ -279,13 +279,13 @@ class AppointmentField extends FieldAbstract
         // Default is last appointment
         $targetCheckAppointment = self::$_lastActiveAppointment[$this->_lastActiveKey];
 
-        if ($this->fieldDefinition['gtap_diff_target_field'] !== null) {
-            if ($this->fieldDefinition['gtap_diff_target_field'] === 'start') {
+        if ($this->fieldDefinition['gtf_diff_target_field'] !== null) {
+            if ($this->fieldDefinition['gtf_diff_target_field'] === 'start') {
                 $targetCheckAppointment = null;
             }
-            if (isset($fieldData[$this->fieldDefinition['gtap_diff_target_field']])) {
+            if (isset($fieldData[$this->fieldDefinition['gtf_diff_target_field']])) {
                 $targetCheckAppointment = $this->agenda->getAppointment(
-                    $fieldData[$this->fieldDefinition['gtap_diff_target_field']]
+                    $fieldData[$this->fieldDefinition['gtf_diff_target_field']]
                 );
             }
         }

--- a/src/Tracker/Field/AppointmentField.php
+++ b/src/Tracker/Field/AppointmentField.php
@@ -147,7 +147,7 @@ class AppointmentField extends FieldAbstract
     {
         if ($currentValue || isset($this->fieldDefinition['gtf_filter_id'])) {
             if ($this->_lastActiveKey && isset($this->fieldDefinition['gtf_filter_id'])) {
-                $fromDate = $this->getFromDate($trackData);
+                $fromDate = $this->getFromDate($trackData, $fieldData);
 
                 if ($fromDate instanceof DateTimeInterface) {
                     $select = $this->agenda->createAppointmentSelect(['gap_id_appointment']);
@@ -274,12 +274,24 @@ class AppointmentField extends FieldAbstract
         return $output;
     }
 
-    public function getFromDate(array $trackData): DateTimeInterface|null
+    public function getFromDate(array $trackData, array $fieldData = []): DateTimeInterface|null
     {
-        $lastActive = self::$_lastActiveAppointment[$this->_lastActiveKey];
+        // Default is last appointment
+        $targetCheckAppointment = self::$_lastActiveAppointment[$this->_lastActiveKey];
 
-        if (($lastActive instanceof Appointment) && $lastActive->isActive()) {
-            $fromDate = $lastActive->getAdmissionTime();
+        if ($this->fieldDefinition['gtap_diff_target_field'] !== null) {
+            if ($this->fieldDefinition['gtap_diff_target_field'] === 'start') {
+                $targetCheckAppointment = null;
+            }
+            if (isset($fieldData[$this->fieldDefinition['gtap_diff_target_field']])) {
+                $targetCheckAppointment = $this->agenda->getAppointment(
+                    $fieldData[$this->fieldDefinition['gtap_diff_target_field']]
+                );
+            }
+        }
+
+        if (($targetCheckAppointment instanceof Appointment) && $targetCheckAppointment->isActive()) {
+            $fromDate = $targetCheckAppointment->getAdmissionTime();
             return $fromDate->setTime(0,0);
         }
 

--- a/src/Tracker/Field/AppointmentField.php
+++ b/src/Tracker/Field/AppointmentField.php
@@ -23,6 +23,7 @@ use Gems\Tracker;
 use Gems\Util\Translated;
 use Zalt\Base\TranslatorInterface;
 use Zalt\Html\Html;
+use Zalt\Html\HtmlElement;
 use Zalt\Model\MetaModelInterface;
 
 /**
@@ -39,14 +40,14 @@ class AppointmentField extends FieldAbstract
     /**
      * Respondent track fields that this field's settings are dependent on.
      *
-     * @var array Null or an array of respondent track fields.
+     * @var array|null an array of respondent track fields.
      */
     protected array|null $_dependsOn = ['gr2t_id_user', 'gr2t_id_organization'];
 
     /**
      * Model settings for this field that may change depending on the dependsOn fields.
      *
-     * @var array Null or an array of model settings that change for this field
+     * @var array|null an array of model settings that change for this field
      */
     protected array|null $_effecteds = ['multiOptions'];
 
@@ -55,7 +56,7 @@ class AppointmentField extends FieldAbstract
      *
      * Shared among all field instances saving to the same respondent track id
      *
-     * @var array of \Gems\Agenda\Appointment)
+     * @var Appointment[]
      */
     protected static array  $_lastActiveAppointment = [];
 
@@ -72,9 +73,9 @@ class AppointmentField extends FieldAbstract
      * The key for the current calculation to self::$_lastActiveAppointment  and
      * self::$_lastActiveAppointmentIds
      *
-     * @var mixed
+     * @var string|int|null
      */
-    protected $_lastActiveKey;
+    protected string|int|null $_lastActiveKey;
 
     /**
      * The format string for outputting appointments
@@ -280,7 +281,7 @@ class AppointmentField extends FieldAbstract
      *
      * @param array $context The current data this object is dependent on
      * @param boolean $new True when the item is a new record not yet saved
-     * @return array (setting => value)
+     * @return array|null (setting => value)
      */
     public function getDataModelDependencyChanges(array $context, bool $new): array|null
     {

--- a/src/Tracker/Field/AppointmentField.php
+++ b/src/Tracker/Field/AppointmentField.php
@@ -112,7 +112,7 @@ class AppointmentField extends FieldAbstract
     /**
      * Calculation the field info display for this type
      *
-     * @param array $currentValue The current value
+     * @param mixed $currentValue The current value
      * @param array $fieldData The other values loaded so far
      * @return mixed the new value
      */
@@ -292,7 +292,9 @@ class AppointmentField extends FieldAbstract
 
         if (($targetCheckAppointment instanceof Appointment) && $targetCheckAppointment->isActive()) {
             $fromDate = $targetCheckAppointment->getAdmissionTime();
-            return $fromDate->setTime(0,0);
+            if ($fromDate instanceof DateTimeImmutable) {
+                return $fromDate->setTime(0,0);
+            }
         }
 
         if (isset($trackData['gr2t_start_date']) && $trackData['gr2t_start_date']) {

--- a/src/Tracker/Field/AppointmentField.php
+++ b/src/Tracker/Field/AppointmentField.php
@@ -82,7 +82,7 @@ class AppointmentField extends FieldAbstract
      *
      * @var string
      */
-    protected string $appointmentTimeFormat = 'd-m-Y H:i';
+    protected string $appointmentTimeFormat = 'j M Y H:i';
 
     public function __construct(
         int $trackId,

--- a/src/Tracker/Field/AppointmentField.php
+++ b/src/Tracker/Field/AppointmentField.php
@@ -138,7 +138,7 @@ class AppointmentField extends FieldAbstract
     /**
      * Calculate the field value using the current values
      *
-     * @param array $currentValue The current value
+     * @param mixed $currentValue The current value
      * @param array $fieldData The other known field values
      * @param array $trackData The currently available track data (track id may be empty)
      * @return string|int|null the new value

--- a/src/Tracker/Model/FieldMaintenanceModel.php
+++ b/src/Tracker/Model/FieldMaintenanceModel.php
@@ -230,6 +230,7 @@ class FieldMaintenanceModel extends UnionModel
         if ($detailed) {
             // Appointment caculcation field
             $this->metaModel->set('gtf_filter_id'); // Set order
+            $this->metaModel->set('gtf_diff_target_field'); // Set order
             $this->metaModel->set('gtf_min_diff_length'); // Set order
             $this->metaModel->set('gtf_min_diff_unit'); // Set order
             $this->metaModel->set('gtf_max_diff_exists', ['multiOptions' => $yesNo]); // Set order
@@ -392,6 +393,9 @@ class FieldMaintenanceModel extends UnionModel
         ]);
 
         $this->metaModel->set('gtf_filter_id', [
+            'elementClass' => 'Hidden'
+        ]);
+        $this->metaModel->set('gtf_diff_target_field', [
             'elementClass' => 'Hidden'
         ]);
         $this->metaModel->set('gtf_min_diff_length', [

--- a/tests/Tracker/Field/AppointmentFieldTest.php
+++ b/tests/Tracker/Field/AppointmentFieldTest.php
@@ -170,7 +170,11 @@ class AppointmentFieldTest extends TestCase
 
     public function testFromDateCalculation(): void
     {
-        $appointmentField = $this->getAppointmentField();
+        $appointmentField = $this->getAppointmentField(
+            fieldDefinition: [
+                'gtf_diff_target_field' => null,
+            ],
+        );
 
         // Diff field not set. (default to track start date)
         $valueFromString = $appointmentField->getFromDate(['gr2t_start_date' => '2000-01-01 15:00:00'], []);
@@ -189,7 +193,7 @@ class AppointmentFieldTest extends TestCase
         // Diff field: specific appointment
         $appointmentField = $this->getAppointmentField(
             fieldDefinition: [
-                'gtap_diff_target_field' => 'A__1001',
+                'gtf_diff_target_field' => 'A__1001',
             ],
         );
 
@@ -200,7 +204,7 @@ class AppointmentFieldTest extends TestCase
         // Diff field: specifically start, with previous field
         $appointmentField = $this->getAppointmentField(
             fieldDefinition: [
-                'gtap_diff_target_field' => 'start',
+                'gtf_diff_target_field' => 'start',
             ],
         );
 
@@ -255,6 +259,9 @@ class AppointmentFieldTest extends TestCase
                 'gtf_filter_id' => 1000,
                 'gtf_min_diff_unit' => 'D',
                 'gtf_min_diff_length' => '1',
+                'gtf_max_diff_exists' => 0,
+                'gtf_uniqueness' => 0,
+                'gtf_diff_target_field' => null,
             ],
             appointmentSelect: $appointmentSelect
         );
@@ -282,6 +289,9 @@ class AppointmentFieldTest extends TestCase
                 'gtf_filter_id' => 1000,
                 'gtf_min_diff_unit' => 'D',
                 'gtf_min_diff_length' => '-1',
+                'gtf_max_diff_exists' => 0,
+                'gtf_uniqueness' => 0,
+                'gtf_diff_target_field' => null,
             ],
             appointmentSelect: $appointmentSelect);
 
@@ -289,6 +299,7 @@ class AppointmentFieldTest extends TestCase
             'gr2t_id_user' => 2000,
             'gr2t_id_organization' => 70,
             'gr2t_start_date' => '2004-01-15 00:00:00',
+            'gtf_max_diff_exists' => 0,
         ]);
 
         $this->assertEquals(2000001, $result);
@@ -315,6 +326,8 @@ class AppointmentFieldTest extends TestCase
                 'gtf_max_diff_exists' => 1,
                 'gtf_max_diff_unit' => 'D',
                 'gtf_max_diff_length' => '2',
+                'gtf_uniqueness' => 0,
+                'gtf_diff_target_field' => null,
             ],
             appointmentSelect: $appointmentSelect
         );
@@ -348,6 +361,8 @@ class AppointmentFieldTest extends TestCase
                 'gtf_min_diff_unit' => 'D',
                 'gtf_min_diff_length' => '1',
                 'gtf_uniqueness' => 1,
+                'gtf_max_diff_exists' => 0,
+                'gtf_diff_target_field' => null,
             ],
             appointmentSelect: $appointmentSelect
         );
@@ -384,6 +399,8 @@ class AppointmentFieldTest extends TestCase
                 'gtf_min_diff_unit' => 'D',
                 'gtf_min_diff_length' => '1',
                 'gtf_uniqueness' => 2,
+                'gtf_max_diff_exists' => 0,
+                'gtf_diff_target_field' => null,
             ],
             appointmentSelect: $appointmentSelect
         );

--- a/tests/Tracker/Field/AppointmentFieldTest.php
+++ b/tests/Tracker/Field/AppointmentFieldTest.php
@@ -1,0 +1,378 @@
+<?php
+
+namespace GemsTest\Tracker\Field;
+
+use Gems\Agenda\Agenda;
+use Gems\Agenda\Appointment;
+use Gems\Agenda\LaminasAppointmentSelect;
+use Gems\Agenda\Repository\ActivityRepository;
+use Gems\Agenda\Repository\LocationRepository;
+use Gems\Agenda\Repository\ProcedureRepository;
+use Gems\Menu\RouteHelper;
+use Gems\Repository\RespondentRepository;
+use Gems\Tracker\Field\AppointmentField;
+use Gems\Util\Translated;
+use PHPUnit\Framework\TestCase;
+use Zalt\Base\TranslatorInterface;
+use Zalt\Html\HtmlElement;
+
+class AppointmentFieldTest extends TestCase
+{
+    private function getAppointmentField(
+        int $trackId = 1,
+        string $fieldKey = 'a__60001',
+        array $fieldDefinition = [],
+        array $trackData = [
+            'gr2t_id_respondent_track' => 1,
+        ],
+        LaminasAppointmentSelect|null $appointmentSelect = null,
+    ): AppointmentField {
+        $translator = $this->getTranslator();
+
+        $agenda = $this->createMock(Agenda::class);
+        $agenda->method('isStatusActive')->willReturnMap([
+            ['AC', true],
+            ['CO', true],
+            ['AB', false],
+            ['CA', false],
+        ]);
+
+        $respondentRepository = $this->createMock(RespondentRepository::class);
+        $respondentRepository->method('getPatientNr')->with(2, 70)->willReturn('TEST001');
+
+        $agenda->method('getAppointment')
+            ->willReturnCallback(function(array|string|int $appointmentData) use ($agenda, $respondentRepository) {
+                return match($appointmentData) {
+                    1234 => new Appointment(
+                        [
+                            'gap_id_appointment' => 1234,
+                            'gap_status' => 'AC',
+                            'gap_admission_time' => '2002-01-15 15:00:00',
+                            'gap_id_user' => 1,
+                            'gap_id_organization' => 70,
+                        ],
+                        $this->getTranslator(),
+                        $agenda,
+                        $this->createMock(ActivityRepository::class),
+                        $this->createMock(LocationRepository::class),
+                        $this->createMock(ProcedureRepository::class),
+                        $this->createMock(RespondentRepository::class),
+                    ),
+                    5678 => new Appointment(
+                        [
+                            'gap_id_appointment' => 5678,
+                            'gap_status' => 'CA',
+                            'gap_admission_time' => '2003-01-01 15:00:00',
+                            'gap_id_user' => 2,
+                            'gap_id_organization' => 70,
+                        ],
+                        $this->getTranslator(),
+                        $agenda,
+                        $this->createMock(ActivityRepository::class),
+                        $this->createMock(LocationRepository::class),
+                        $this->createMock(ProcedureRepository::class),
+                        $respondentRepository,
+                    ),
+                    default => new Appointment(
+                        [
+                            'gap_id_appointment' => 1,
+                        ],
+                        $this->getTranslator(),
+                        $agenda,
+                        $this->createMock(ActivityRepository::class),
+                        $this->createMock(LocationRepository::class),
+                        $this->createMock(ProcedureRepository::class),
+                        $respondentRepository,
+                    )
+                };
+            });
+        if ($appointmentSelect) {
+            $agenda->method('createAppointmentSelect')->willReturn($appointmentSelect);
+        }
+
+        $routeHelper = $this->createMock(RouteHelper::class);
+        $routeHelper->method('getRouteUrl')->willReturnCallback(function(string $name, array $params = []) {
+            if (!$name === 'respondent.appointments.show') {
+                return null;
+            }
+            if (isset($params['id1'], $params['id2'], $params['aid'])) {
+                return '/respondent/' . $params['id1'] . '/' . $params['id2'] . '/appointments/' . $params['aid'];
+            }
+        });
+
+        $appointmentField = new AppointmentField(
+            $trackId,
+            $fieldKey,
+            $fieldDefinition,
+            $translator,
+            new Translated($translator),
+            $agenda,
+            $routeHelper,
+        );
+
+        $appointmentField->calculationStart($trackData);
+
+        return $appointmentField;
+    }
+
+    private function getAppointment(
+        array $appointmentData = [
+            'gap_id_appointment' => 1,
+        ]
+    ): Appointment
+    {
+        return new Appointment(
+            $appointmentData,
+            $this->getTranslator(),
+            $this->createMock(Agenda::class),
+            $this->createMock(ActivityRepository::class),
+            $this->createMock(LocationRepository::class),
+            $this->createMock(ProcedureRepository::class),
+            $this->createMock(RespondentRepository::class),
+        );
+    }
+
+    private function getTranslator(): TranslatorInterface
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->method('_')->willReturnArgument(0);
+        return $translator;
+    }
+
+    public function testCalculateFieldInfo(): void
+    {
+        $appointmentField = $this->getAppointmentField();
+
+        $noValue = $appointmentField->calculateFieldInfo(null, []);
+        $this->assertNull($noValue);
+
+        $unknownAppointment = $appointmentField->calculateFieldInfo(999, []);
+        $this->assertNull($unknownAppointment);
+
+        $inactiveAppointment = $appointmentField->calculateFieldInfo(5678, []);
+        $this->assertNull($inactiveAppointment);
+
+        $activeAppointment = $appointmentField->calculateFieldInfo(1234, []);
+        $this->assertEquals('15-01-2002 15:00', $activeAppointment);
+    }
+
+
+    public function testCalculateFieldValueNoValue(): void
+    {
+        $appointmentField = $this->getAppointmentField();
+
+        $value = $appointmentField->calculateFieldValue(null, [], []);
+
+        $this->assertNull($value);
+
+        $value2 = $appointmentField->calculateFieldValue('someValue', [], []);
+
+        $this->assertNotNull($value2);
+    }
+
+    public function testFromDateCalculation(): void
+    {
+        $appointmentField = $this->getAppointmentField();
+
+        $valueFromString = $appointmentField->getFromDate(['gr2t_start_date' => '2000-01-01 15:00:00']);
+        $this->assertEquals('2000-01-01 00:00:00', $valueFromString->format('Y-m-d H:i:s'));
+
+        $valueFromDateTime = $appointmentField->getFromDate(['gr2t_start_date' => new \DateTimeImmutable('2001-01-01 00:00:00')]);
+        $this->assertEquals('2001-01-01 00:00:00', $valueFromDateTime->format('Y-m-d H:i:s'));
+
+        $appointmentField->setLastActiveAppointmentFromValue(1234);
+        $valueFromLastAppointment = $appointmentField->getFromDate(['gr2t_start_date' => '2000-01-01 00:00:00']);
+        $this->assertEquals('2002-01-15 00:00:00', $valueFromLastAppointment->format('Y-m-d H:i:s'));
+    }
+
+    public function testCalculationStart(): void
+    {
+        $appointmentField = $this->getAppointmentField(trackData: []);
+        $this->assertNull($appointmentField->getLastActiveKey());
+
+        $appointmentField->calculationStart(['gr2t_id_respondent_track' => 123]);
+        $this->assertEquals(123, $appointmentField->getLastActiveKey());
+
+        $appointmentField = $this->getAppointmentField(trackData: []);
+        $appointmentField->calculationStart(['gr2t_id_user' => 987, 'gr2t_id_organization' => 70]);
+        $this->assertEquals('987__70', $appointmentField->getLastActiveKey());
+    }
+
+    public function testShowAppointment(): void
+    {
+        $appointmentField = $this->getAppointmentField();
+
+        $nullResult = $appointmentField->showAppointment(null);
+        $this->assertEquals('Unknown', $nullResult);
+
+        $displayString = $appointmentField->showAppointment(1234);
+        $this->assertEquals('15-01-2002 15:00', $displayString);
+
+        $displayUrl = $appointmentField->showAppointment(5678);
+        $this->assertInstanceOf(HtmlElement::class, $displayUrl);
+        $this->assertEquals('/respondent/TEST001/70/appointments/5678', $displayUrl->getAttrib('href'));
+    }
+
+    public function testCalculateFieldValue1DayMinDiff(): void
+    {
+        $appointmentSelect = $this->createMock(LaminasAppointmentSelect::class);
+        $appointmentSelect->expects($this->once())->method('onlyActive')->willReturnSelf();
+        $appointmentSelect->expects($this->once())->method('forFilterId')->with(1000)->willReturnSelf();
+        $appointmentSelect->expects($this->once())->method('forRespondent')->with(2000, 70)->willReturnSelf();
+        $appointmentSelect->expects($this->once())->method('forPeriod')->with(
+            new \DateTimeImmutable('2004-01-16 00:00:00'),
+            null,
+            true
+        )->willReturnSelf();
+        $appointmentSelect->expects($this->once())->method('fetchOne')->willReturn(2000001);
+
+        $appointmentField = $this->getAppointmentField(
+            fieldDefinition: [
+                'gtf_filter_id' => 1000,
+                'gtf_min_diff_unit' => 'D',
+                'gtf_min_diff_length' => '1',
+            ],
+            appointmentSelect: $appointmentSelect
+        );
+
+        $result = $appointmentField->calculateFieldValue(123, [], [
+            'gr2t_id_user' => 2000,
+            'gr2t_id_organization' => 70,
+            'gr2t_start_date' => '2004-01-15 00:00:00',
+        ]);
+
+        $this->assertEquals(2000001, $result);
+    }
+
+    public function testCalculateFieldValueMinus1DayMinDiff(): void
+    {
+        $appointmentSelect = $this->createMock(LaminasAppointmentSelect::class);
+        $appointmentSelect->expects($this->once())->method('onlyActive')->willReturnSelf();
+        $appointmentSelect->expects($this->once())->method('forFilterId')->with(1000)->willReturnSelf();
+        $appointmentSelect->expects($this->once())->method('forRespondent')->with(2000, 70)->willReturnSelf();
+        $appointmentSelect->expects($this->once())->method('forPeriod')->with(null, new \DateTimeImmutable('2004-01-14 00:00:00'), false)->willReturnSelf();
+        $appointmentSelect->expects($this->once())->method('fetchOne')->willReturn(2000001);
+
+        $appointmentField = $this->getAppointmentField(
+            fieldDefinition: [
+                'gtf_filter_id' => 1000,
+                'gtf_min_diff_unit' => 'D',
+                'gtf_min_diff_length' => '-1',
+            ],
+            appointmentSelect: $appointmentSelect);
+
+        $result = $appointmentField->calculateFieldValue(123, [], [
+            'gr2t_id_user' => 2000,
+            'gr2t_id_organization' => 70,
+            'gr2t_start_date' => '2004-01-15 00:00:00',
+        ]);
+
+        $this->assertEquals(2000001, $result);
+    }
+
+    public function testCalculateFieldValue1DayMaxDiff(): void
+    {
+        $appointmentSelect = $this->createMock(LaminasAppointmentSelect::class);
+        $appointmentSelect->expects($this->once())->method('onlyActive')->willReturnSelf();
+        $appointmentSelect->expects($this->once())->method('forFilterId')->with(1000)->willReturnSelf();
+        $appointmentSelect->expects($this->once())->method('forRespondent')->with(2000, 70)->willReturnSelf();
+        $appointmentSelect->expects($this->once())->method('forPeriod')->with(
+            new \DateTimeImmutable('2004-01-16 00:00:00'),
+            new \DateTimeImmutable('2004-01-17 00:00:00'),
+            true
+        )->willReturnSelf();
+        $appointmentSelect->expects($this->once())->method('fetchOne')->willReturn(2000001);
+
+        $appointmentField = $this->getAppointmentField(
+            fieldDefinition: [
+                'gtf_filter_id' => 1000,
+                'gtf_min_diff_unit' => 'D',
+                'gtf_min_diff_length' => '1',
+                'gtf_max_diff_exists' => 1,
+                'gtf_max_diff_unit' => 'D',
+                'gtf_max_diff_length' => '2',
+            ],
+            appointmentSelect: $appointmentSelect
+        );
+
+        $result = $appointmentField->calculateFieldValue(123, [], [
+            'gr2t_id_user' => 2000,
+            'gr2t_id_organization' => 70,
+            'gr2t_start_date' => '2004-01-15 00:00:00',
+        ]);
+
+        $this->assertEquals(2000001, $result);
+    }
+
+    public function testCalculateFieldValueUniqueInTrack(): void
+    {
+        $appointmentSelect = $this->createMock(LaminasAppointmentSelect::class);
+        $appointmentSelect->expects($this->once())->method('onlyActive')->willReturnSelf();
+        $appointmentSelect->expects($this->once())->method('forFilterId')->with(1000)->willReturnSelf();
+        $appointmentSelect->expects($this->once())->method('forRespondent')->with(2000, 70)->willReturnSelf();
+        $appointmentSelect->expects($this->once())->method('forPeriod')->with(
+            new \DateTimeImmutable('2002-01-16 00:00:00'),
+            null,
+            true
+        )->willReturnSelf();
+        $appointmentSelect->expects($this->once())->method('uniqueInTrackInstance')->with([1234 => 1234])->willReturnSelf();
+        $appointmentSelect->expects($this->once())->method('fetchOne')->willReturn(2000002);
+
+        $appointmentField = $this->getAppointmentField(
+            fieldDefinition: [
+                'gtf_filter_id' => 1000,
+                'gtf_min_diff_unit' => 'D',
+                'gtf_min_diff_length' => '1',
+                'gtf_uniqueness' => 1,
+            ],
+            appointmentSelect: $appointmentSelect
+        );
+
+        $appointmentField->setLastActiveAppointmentFromValue(1234);
+
+        $result = $appointmentField->calculateFieldValue(123, [], [
+            'gr2t_id_user' => 2000,
+            'gr2t_id_respondent_track' => 500,
+            'gr2t_id_organization' => 70,
+            'gr2t_start_date' => '2004-01-15 00:00:00',
+        ]);
+
+        $this->assertEquals(2000002, $result);
+    }
+
+    public function testCalculateFieldValueUniqueInTrackType(): void
+    {
+        $appointmentSelect = $this->createMock(LaminasAppointmentSelect::class);
+        $appointmentSelect->expects($this->once())->method('onlyActive')->willReturnSelf();
+        $appointmentSelect->expects($this->once())->method('forFilterId')->with(1000)->willReturnSelf();
+        $appointmentSelect->expects($this->once())->method('forRespondent')->with(2000, 70)->willReturnSelf();
+        $appointmentSelect->expects($this->once())->method('forPeriod')->with(
+            new \DateTimeImmutable('2002-01-16 00:00:00'),
+            null,
+            true
+        )->willReturnSelf();
+        $appointmentSelect->expects($this->once())->method('uniqueForTrackId')->with(1, 500, [1234 => 1234])->willReturnSelf();
+        $appointmentSelect->expects($this->once())->method('fetchOne')->willReturn(2000002);
+
+        $appointmentField = $this->getAppointmentField(
+            fieldDefinition: [
+                'gtf_filter_id' => 1000,
+                'gtf_min_diff_unit' => 'D',
+                'gtf_min_diff_length' => '1',
+                'gtf_uniqueness' => 2,
+            ],
+            appointmentSelect: $appointmentSelect
+        );
+
+        $appointmentField->setLastActiveAppointmentFromValue(1234);
+
+        $result = $appointmentField->calculateFieldValue(123, [], [
+            'gr2t_id_user' => 2000,
+            'gr2t_id_respondent_track' => 500,
+            'gr2t_id_organization' => 70,
+            'gr2t_start_date' => '2004-01-15 00:00:00',
+        ]);
+
+        $this->assertEquals(2000002, $result);
+    }
+}

--- a/tests/Tracker/Field/AppointmentFieldTest.php
+++ b/tests/Tracker/Field/AppointmentFieldTest.php
@@ -107,7 +107,7 @@ class AppointmentFieldTest extends TestCase
 
         $routeHelper = $this->createMock(RouteHelper::class);
         $routeHelper->method('getRouteUrl')->willReturnCallback(function(string $name, array $params = []) {
-            if (!$name === 'respondent.appointments.show') {
+            if (!($name === 'respondent.appointments.show')) {
                 return null;
             }
             if (isset($params['id1'], $params['id2'], $params['aid'])) {
@@ -128,23 +128,6 @@ class AppointmentFieldTest extends TestCase
         $appointmentField->calculationStart($trackData);
 
         return $appointmentField;
-    }
-
-    private function getAppointment(
-        array $appointmentData = [
-            'gap_id_appointment' => 1,
-        ]
-    ): Appointment
-    {
-        return new Appointment(
-            $appointmentData,
-            $this->getTranslator(),
-            $this->createMock(Agenda::class),
-            $this->createMock(ActivityRepository::class),
-            $this->createMock(LocationRepository::class),
-            $this->createMock(ProcedureRepository::class),
-            $this->createMock(RespondentRepository::class),
-        );
     }
 
     private function getTranslator(): TranslatorInterface
@@ -168,7 +151,7 @@ class AppointmentFieldTest extends TestCase
         $this->assertNull($inactiveAppointment);
 
         $activeAppointment = $appointmentField->calculateFieldInfo(1234, []);
-        $this->assertEquals('15-01-2002 15:00', $activeAppointment);
+        $this->assertEquals('15 Jan 2002 15:00', $activeAppointment);
     }
 
 


### PR DESCRIPTION
Add a field in the appointment field config, to specify from which Appointment field, or track start to calculate the difference with. Instead of always defaulting to the previous field.