### PR TITLE
Always show consent fields when undeleting

### DIFF
--- a/src/Snippets/Respondent/DeleteRespondentSnippet.php
+++ b/src/Snippets/Respondent/DeleteRespondentSnippet.php
@@ -140,11 +140,9 @@ class DeleteRespondentSnippet extends ChangeReceptionCodeSnippetAbstract
 
         if (! in_array('restore_tracks', $this->editItems)) {
             $this->editItems[] = 'restore_tracks';
-            if (!$this->respondent->getConsent()?->canBeUsed()) {
-                foreach ($this->respondentModel->consentFields as $field) {
-                    $this->editItems[] = $field;
-                    $this->editItems[] = 'old_' . $field;
-                }
+            foreach ($this->respondentModel->consentFields as $field) {
+                $this->editItems[] = $field;
+                $this->editItems[] = 'old_' . $field;
             }
         }
         return true;


### PR DESCRIPTION
This fixes an issue where consent fields were shown in the undelete screen only when the consent code was not 'Yes'. When the consent code was Yes, the undelete action would throw an error because the consent fields were missing from the expected input.

Fixes: CPRSD-146