### PR TITLE
Dev/batched messeages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -120,6 +120,7 @@
         "symfony/serializer": "^6.4",
         "symfony/string": "^6.4",
         "symfony/translation": "^6.4",
+        "symfony/uid": "^6.4",
         "symfony/validator": "^6.4",
         "symfony/yaml": "^6.4",
         "twig/twig": "^3.9"

--- a/configs/db/tables/gems__batch.20.sql
+++ b/configs/db/tables/gems__batch.20.sql
@@ -12,7 +12,7 @@ CREATE TABLE if not exists gems__batch (
 
     gba_info                text null,
 
-    gba_finished           timestamp not null default current_timestamp,
+    gba_finished           timestamp null default current_timestamp,
     gba_created            timestamp not null default current_timestamp,
     gba_changed            timestamp not null default current_timestamp ON UPDATE current_timestamp,
 

--- a/configs/db/tables/gems__batch.20.sql
+++ b/configs/db/tables/gems__batch.20.sql
@@ -5,7 +5,7 @@ CREATE TABLE if not exists gems__batch (
     gba_name               varchar(64) null,
     gba_group              varchar(64) null,
     gba_status             varchar(64) not null,
-    gba_synchronous        tinyint(64) not null default 0,
+    gba_synchronous        tinyint(1) not null default 0,
 
     gba_message            JSON null,
     gba_message_class      varchar(128) null,

--- a/configs/db/tables/gems__batch.20.sql
+++ b/configs/db/tables/gems__batch.20.sql
@@ -12,7 +12,8 @@ CREATE TABLE if not exists gems__batch (
 
     gba_info                text null,
 
-    gba_finished           timestamp null default current_timestamp,
+    gba_started            timestamp null,
+    gba_finished           timestamp null,
     gba_created            timestamp not null default current_timestamp,
     gba_changed            timestamp not null default current_timestamp ON UPDATE current_timestamp,
 

--- a/configs/db/tables/gems__batch.20.sql
+++ b/configs/db/tables/gems__batch.20.sql
@@ -1,0 +1,23 @@
+CREATE TABLE if not exists gems__batch (
+    gba_id                 char(36) not null,
+    gba_iteration          int unsigned not null,
+
+    gba_name               varchar(64) null,
+    gba_group              varchar(64) null,
+    gba_status             varchar(64) not null,
+    gba_synchronous        tinyint(64) not null default 0,
+
+    gba_message            JSON null,
+    gba_message_class      varchar(128) null,
+
+    gba_info                text null,
+
+    gba_finished           timestamp not null default current_timestamp,
+    gba_created            timestamp not null default current_timestamp,
+    gba_changed            timestamp not null default current_timestamp ON UPDATE current_timestamp,
+
+    PRIMARY KEY (gba_id, gba_iteration)
+)
+    ENGINE=InnoDB
+    AUTO_INCREMENT = 1000
+    CHARACTER SET 'utf8mb4' COLLATE 'utf8mb4_unicode_ci';

--- a/src/Command/ClearMessengerBatch.php
+++ b/src/Command/ClearMessengerBatch.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gems\Command;
+
+use DateInterval;
+use Exception;
+use Gems\Messenger\Batch\BatchStoreInterface;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(name: 'app:clear-messenger-batch', description: 'Clear old messenger batch data')]
+class ClearMessengerBatch extends Command
+{
+
+    public function __construct(
+        private readonly ContainerInterface $container,
+    )
+    {
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        $this->addArgument(
+            name: 'days',
+            mode: InputArgument::OPTIONAL,
+            description: 'Age in days of items to remove. Can also be a DateInterval notation (e.g. P7D)',
+            default: '7',
+        );
+
+        $this->addArgument(
+            name: 'group',
+            mode: InputArgument::OPTIONAL,
+            description: 'Optional Group to clear',
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $removeInterval = $this->getInterval($input);
+
+        /** @var BatchStoreInterface $batchStore */
+        $batchStore = $this->container->get(BatchStoreInterface::class);
+
+        $batchStore->clearOldBatches($removeInterval);
+
+        return Command::SUCCESS;
+    }
+
+    protected function getInterval(InputInterface $input): DateInterval
+    {
+        $days = $input->getArgument('days');
+        if (ctype_digit($days)) {
+            return new DateInterval('P' . (int)$days . 'D');
+        }
+
+        try {
+            $interval = new DateInterval($days);
+            return $interval;
+        } catch (Exception $e) {
+            throw new Exception(sprintf('Input days (%s) is not an int or a DateInterval string', $days));
+        }
+    }
+}

--- a/src/Command/RunCommJob.php
+++ b/src/Command/RunCommJob.php
@@ -78,7 +78,8 @@ class RunCommJob extends Command
 
         /** @var MessengerBatchRepository $messengerBatchRepository */
         $messengerBatchRepository = $this->container->get(MessengerBatchRepository::class);
-        $batch = $messengerBatchRepository->createBatch('CommJob', 'CommJob', true);
+        $now = new \DateTimeImmutable();
+        $batch = $messengerBatchRepository->createBatch('CommJob ' . $now->format('Y-m-d H:i:s'), 'CommJob', true);
         foreach($jobs as $jobData) {
             $commJobMessage = new CommJob($jobData);
             $batch->addMessage($commJobMessage);

--- a/src/Command/RunCommJob.php
+++ b/src/Command/RunCommJob.php
@@ -3,10 +3,12 @@
 namespace Gems\Command;
 
 use Gems\Console\ConsoleSettings;
+use Gems\Messenger\Batch\MessengerBatchRepository;
 use Gems\Messenger\Message\CommJob;
 use Gems\Repository\CommJobRepository;
 use Gems\Util\Lock\CommJobLock;
 use Gems\Util\Lock\MaintenanceLock;
+use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -19,12 +21,7 @@ use Symfony\Component\Messenger\Stamp\HandledStamp;
 class RunCommJob extends Command
 {
     public function __construct(
-        protected CommJobLock $commJobLock,
-        protected MaintenanceLock $maintenanceLock,
-        protected MessageBusInterface $messageBus,
-        protected CommJobRepository $commJobRepository,
-        protected ConsoleSettings $consoleSettings,
-        protected array $config,
+        private readonly ContainerInterface $container,
     )
     {
         parent::__construct();
@@ -37,22 +34,38 @@ class RunCommJob extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        if ($this->maintenanceLock->isLocked()) {
+        /**
+         * @var MaintenanceLock $maintenanceLock
+         */
+        $maintenanceLock = $this->container->get(MaintenanceLock::class);
+
+        if ($maintenanceLock->isLocked()) {
             $output->writeln('<error>Cannot run cron job in maintenance mode.</error>');
             return static::FAILURE;
         }
-        if ($this->commJobLock->isLocked()) {
+
+        /**
+         * @var CommJobLock $commJobLock
+         */
+        $commJobLock = $this->container->get(CommJobLock::class);
+        if ($commJobLock->isLocked()) {
             $output->writeln('<error>Cron jobs turned off.</error>');
             return static::FAILURE;
         }
 
-        $this->consoleSettings->setConsoleUser();
+        /**
+         * @var ConsoleSettings $consoleSettings
+         */
+        $consoleSettings = $this->container->get(ConsoleSettings::class);
+        $consoleSettings->setConsoleUser();
 
-        $jobs = $this->commJobRepository->getAutomaticJobs();
+        /** @var CommJobRepository $commJobRepository */
+        $commJobRepository = $this->container->get(CommJobRepository::class);
+        $jobs = $commJobRepository->getAutomaticJobs();
 
         $id = $input->getArgument('id');
         if ($id !== null) {
-            $jobs = $this->commJobRepository->getActiveJobs();
+            $jobs = $commJobRepository->getActiveJobs();
             $jobs = array_filter($jobs, function ($job) use ($id) {
                 return $job['gcj_id_job'] == $id;
             });
@@ -61,18 +74,26 @@ class RunCommJob extends Command
             }
         }
 
-        $this->commJobRepository->clearTokenQueue();
+        $commJobRepository->clearTokenQueue();
+
+        /** @var MessengerBatchRepository $messengerBatchRepository */
+        $messengerBatchRepository = $this->container->get(MessengerBatchRepository::class);
+        $batch = $messengerBatchRepository->createBatch('CommJob', 'CommJob', true);
         foreach($jobs as $jobData) {
             $commJobMessage = new CommJob($jobData);
-            $envelope = $this->messageBus->dispatch($commJobMessage);
-            /**
-             * @var HandledStamp $stamp
-             */
-            $stamp = $envelope->last(HandledStamp::class);
-            $output->writeln($stamp->getResult());
+            $batch->addMessage($commJobMessage);
         }
 
-        $output->writeln(sprintf('<info>Executed %d jobs</info>', count($jobs)));
+        $messengerBatchRepository->dispatch($batch);
+
+        $output->writeln(sprintf('<info>Dispatched %d jobs</info>', count($jobs)));
+
+        /** @var MessengerBatchRepository $messengerBatchRepository */
+        $messengerBatchRepository = $this->container->get(MessengerBatchRepository::class);
+        $messages = $messengerBatchRepository->getBatchInfoList($batch->batchId);
+        foreach($messages as $message) {
+            $output->writeln(sprintf('<info>%s</info>', $message));
+        }
 
         return static::SUCCESS;
     }

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -44,6 +44,8 @@ use Gems\Menu\RouteHelper;
 use Gems\Menu\RouteHelperFactory;
 use Gems\Messenger\MessengerFactory;
 use Gems\Messenger\TransportFactory;
+use Gems\Messenger\Batch\BatchStoreInterface;
+use Gems\Messenger\Batch\DatabaseBatchStore;
 use Gems\Middleware\FlashMessageMiddleware;
 use Gems\Model\Bridge\GemsFormBridge;
 use Gems\Model\Bridge\GemsValidatorBridge;
@@ -445,8 +447,6 @@ class ConfigProvider
 
                 \Symfony\Component\Mailer\Transport\TransportInterface::class => MailTransportFactory::class,
 
-                BatchStoreInterface::class => DatabaseBatchStore::class,
-
                 Serializer::class => SymfonySerializerFactory::class,
                 ValidatorInterface::class => SymfonyValidatorFactory::class,
 
@@ -487,6 +487,7 @@ class ConfigProvider
 
                 // Messenger
                 'messenger.bus.default' => MessageBusInterface::class,
+                BatchStoreInterface::class => DatabaseBatchStore::class,
 
                 // Session
                 //SessionPersistenceInterface::class => CacheSessionPersistence::class,

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -445,6 +445,8 @@ class ConfigProvider
 
                 \Symfony\Component\Mailer\Transport\TransportInterface::class => MailTransportFactory::class,
 
+                BatchStoreInterface::class => DatabaseBatchStore::class,
+
                 Serializer::class => SymfonySerializerFactory::class,
                 ValidatorInterface::class => SymfonyValidatorFactory::class,
 

--- a/src/Db/ResultFetcher.php
+++ b/src/Db/ResultFetcher.php
@@ -147,7 +147,7 @@ class ResultFetcher
         return $this->db->query($select, $params, $resultSet);
     }
 
-    public function insertIntoTable(string $tableName, array $values): int
+    public function insertIntoTable(string $tableName, array|Select $values): int
     {
         $table = new TableGateway($tableName, $this->getAdapter());
         $table->insert($values);

--- a/src/Messenger/Batch/Batch.php
+++ b/src/Messenger/Batch/Batch.php
@@ -48,4 +48,9 @@ class Batch
     {
         return $this->messages;
     }
+
+    public function clearMessages(): void
+    {
+        $this->messages = [];
+    }
 }

--- a/src/Messenger/Batch/Batch.php
+++ b/src/Messenger/Batch/Batch.php
@@ -56,6 +56,17 @@ class Batch
         return $this->messages;
     }
 
+    public function getPercent(): float
+    {
+        if (!$this->totalItems) {
+            return 0;
+        }
+        if (!$this->success || $this->success === 0) {
+            return 0;
+        }
+        return $this->success / $this->totalItems;
+    }
+
     public function clearMessages(): void
     {
         $this->messages = [];

--- a/src/Messenger/Batch/Batch.php
+++ b/src/Messenger/Batch/Batch.php
@@ -18,9 +18,16 @@ class Batch
         public readonly DateTimeInterface $created,
         public readonly string|null $name = null,
         public readonly string|null $group = null,
+        public readonly bool $isChain = false,
         public readonly DateTimeInterface|null $finished = null,
-        public readonly BatchStatus $status = BatchStatus::PENDING,
-        public readonly bool $isChain = false
+        public readonly int|null $totalItems = null,
+        public readonly int|null $pending = null,
+        public readonly int|null $running = null,
+        public readonly int|null $success = null,
+        public readonly int|null $failed = null,
+
+
+
     )
     {
     }

--- a/src/Messenger/Batch/Batch.php
+++ b/src/Messenger/Batch/Batch.php
@@ -16,11 +16,11 @@ class Batch
     public function __construct(
         public readonly string $batchId,
         public readonly DateTimeInterface $created,
-        public string|null $name = null,
-        public string|null $group = null,
+        public readonly string|null $name = null,
+        public readonly string|null $group = null,
         public readonly DateTimeInterface|null $finished = null,
         public readonly BatchStatus $status = BatchStatus::PENDING,
-        public bool $isChain = false
+        public readonly bool $isChain = false
     )
     {
     }

--- a/src/Messenger/Batch/Batch.php
+++ b/src/Messenger/Batch/Batch.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gems\Messenger\Batch;
+
+use DateTimeInterface;
+
+class Batch
+{
+    /*
+     * @var object[]
+     */
+    private array $messages = [];
+
+    public function __construct(
+        public readonly string $batchId,
+        public readonly DateTimeInterface $created,
+        public string|null $name = null,
+        public string|null $group = null,
+        public readonly DateTimeInterface|null $finished = null,
+        public readonly BatchStatus $status = BatchStatus::PENDING,
+        public bool $isChain = false
+    )
+    {
+    }
+
+    public function addMessage(object $message): void
+    {
+        $this->messages[] = $message;
+    }
+
+    /**
+     * @return object[]
+     */
+    public function getCurrentMessages(): array
+    {
+        return $this->messages;
+    }
+}

--- a/src/Messenger/Batch/Batch.php
+++ b/src/Messenger/Batch/Batch.php
@@ -31,6 +31,17 @@ class Batch
     }
 
     /**
+     * @param object[] $messages
+     * @return void
+     */
+    public function addMessages(array $messages): void
+    {
+        foreach ($messages as $message) {
+            $this->addMessage($message);
+        }
+    }
+
+    /**
      * @return object[]
      */
     public function getCurrentMessages(): array

--- a/src/Messenger/Batch/BatchMiddleware.php
+++ b/src/Messenger/Batch/BatchMiddleware.php
@@ -8,6 +8,7 @@ use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
 use Symfony\Component\Messenger\Middleware\StackInterface;
+use Symfony\Component\Messenger\Stamp\HandledStamp;
 
 class BatchMiddleware implements MiddlewareInterface
 {
@@ -22,18 +23,44 @@ class BatchMiddleware implements MiddlewareInterface
     {
         /** @var BatchStamp|null $stamp */
         $stamp = $envelope->last(BatchStamp::class);
+        if (!$stamp) {
+            return $stack->next()->handle($envelope, $stack);
+        }
 
-        $envelope = $stack->next()->handle($envelope, $stack);
-        if ($stamp) {
+        try {
+            $this->batchRepository->setIterationStatus($stamp->batchId, $stamp->iteration, BatchStatus::RUNNING);
+
+            $envelope = $stack->next()->handle($envelope, $stack);
+            $handledStamp =$envelope->last(HandledStamp::class);
+            $result = $handledStamp?->getResult();
+
+            $message = null;
+            if (is_string($result)) {
+                $message = $result;
+            }
+
             $batch = $this->batchRepository->getBatch($stamp->batchId);
-            $this->batchRepository->setIterationFinished($stamp->batchId, $stamp->iteration);
+            $this->batchRepository->setIterationStatus($stamp->batchId, $stamp->iteration, BatchStatus::SUCCESS, $message);
 
             if ($batch->isChain) {
-                $nextMessage = $this->batchRepository->getBatchIterationMessage($stamp->batchId, $stamp->iteration+1);
+                $nextMessage = $this->batchRepository->getBatchIterationMessage($stamp->batchId, $stamp->iteration + 1);
                 if ($nextMessage) {
-                    $this->messageBus->dispatch($nextMessage);
+                    $this->messageBus->dispatch($nextMessage, [
+                        new BatchStamp($stamp->batchId, $stamp->iteration + 1),
+                    ]);
                 }
             }
+
+
+        } catch (\Throwable $e) {
+            $this->batchRepository->setIterationStatus(
+                $stamp->batchId,
+                $stamp->iteration,
+                BatchStatus::FAILED,
+                $e->getMessage()
+            );
+
+            throw $e;
         }
 
         return $envelope;

--- a/src/Messenger/Batch/BatchMiddleware.php
+++ b/src/Messenger/Batch/BatchMiddleware.php
@@ -66,6 +66,10 @@ class BatchMiddleware implements MiddlewareInterface
                 BatchStatus::FAILED,
                 $e->getMessage()
             );
+            $batch = $batchRepository->getBatch($stamp->batchId);
+            if ($batch->isChain) {
+                $batchRepository->failChain($stamp->batchId, $stamp->iteration);
+            }
 
             throw $e;
         }

--- a/src/Messenger/Batch/BatchMiddleware.php
+++ b/src/Messenger/Batch/BatchMiddleware.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gems\Messenger\Batch;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
+use Symfony\Component\Messenger\Middleware\StackInterface;
+
+class BatchMiddleware implements MiddlewareInterface
+{
+    public function __construct(
+        private readonly MessengerBatchRepository $batchRepository,
+        private readonly MessageBusInterface $messageBus,
+    )
+    {
+    }
+
+    public function handle(Envelope $envelope, StackInterface $stack): Envelope
+    {
+        /** @var BatchStamp|null $stamp */
+        $stamp = $envelope->last(BatchStamp::class);
+
+        $envelope = $stack->next()->handle($envelope, $stack);
+        if ($stamp) {
+            $batch = $this->batchRepository->getBatch($stamp->batchId);
+            $this->batchRepository->setIterationFinished($stamp->batchId, $stamp->iteration);
+
+            if ($batch->isChain) {
+                $nextMessage = $this->batchRepository->getBatchIterationMessage($stamp->batchId, $stamp->iteration+1);
+                if ($nextMessage) {
+                    $this->messageBus->dispatch($nextMessage);
+                }
+            }
+        }
+
+        return $envelope;
+    }
+}

--- a/src/Messenger/Batch/BatchStamp.php
+++ b/src/Messenger/Batch/BatchStamp.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gems\Messenger\Batch;
+
+use Symfony\Component\Messenger\Stamp\StampInterface;
+
+class BatchStamp implements StampInterface
+{
+    public function __construct(
+        public readonly string $batchId,
+        public readonly int $iteration,
+    )
+    {
+    }
+}

--- a/src/Messenger/Batch/BatchStatus.php
+++ b/src/Messenger/Batch/BatchStatus.php
@@ -7,6 +7,5 @@ enum BatchStatus: string
     case SUCCESS = 'success';
     case FAILED = 'failed';
     case RUNNING = 'running';
-
     case PENDING = 'pending';
 }

--- a/src/Messenger/Batch/BatchStatus.php
+++ b/src/Messenger/Batch/BatchStatus.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Gems\Messenger\Batch;
+
+enum BatchStatus: string
+{
+    case SUCCESS = 'success';
+    case FAILED = 'failed';
+    case RUNNING = 'running';
+
+    case PENDING = 'pending';
+}

--- a/src/Messenger/Batch/BatchStoreInterface.php
+++ b/src/Messenger/Batch/BatchStoreInterface.php
@@ -8,6 +8,8 @@ interface BatchStoreInterface
     public function exists(string $batchId): bool;
     public function getBatch(string $batchId): Batch|null;
 
+    public function getBatchInfoList(string $batchId): array;
+
     public function getBatchIterationMessage(string $batchId, int $iteration): object|null;
 
     public function isPending(string $batchId): bool;
@@ -16,7 +18,9 @@ interface BatchStoreInterface
 
     public function save(Batch $batch): void;
 
-    public function setIterationFinished(string $batchId, int $iteration): void;
+    public function setIterationFinished(string $batchId, int $iteration, string|null $message = null): void;
+
+    public function setIterationStatus(string $batchId, int $iteration, BatchStatus $status, string|null $message = null): void;
 
 
 

--- a/src/Messenger/Batch/BatchStoreInterface.php
+++ b/src/Messenger/Batch/BatchStoreInterface.php
@@ -6,19 +6,20 @@ interface BatchStoreInterface
 {
     public function count(string $batchId): int;
     public function exists(string $batchId): bool;
+
+    public function failChain(string $batchId, int $failedIteration): void;
+
     public function getBatch(string $batchId): Batch|null;
 
     public function getBatchInfoList(string $batchId): array;
 
     public function getBatchIterationMessage(string $batchId, int $iteration): object|null;
 
-    public function isPending(string $batchId): bool;
+    public function hasPending(string $batchId): bool;
 
     public function isRunning(string $batchId): bool;
 
     public function save(Batch $batch): void;
-
-    public function setIterationFinished(string $batchId, int $iteration, string|null $message = null): void;
 
     public function setIterationStatus(string $batchId, int $iteration, BatchStatus $status, string|null $message = null): void;
 

--- a/src/Messenger/Batch/BatchStoreInterface.php
+++ b/src/Messenger/Batch/BatchStoreInterface.php
@@ -4,7 +4,10 @@ namespace Gems\Messenger\Batch;
 
 interface BatchStoreInterface
 {
+    public function clearOldBatches(\DateInterval|null $dateInterval = null): void;
+
     public function count(string $batchId): int;
+
     public function exists(string $batchId): bool;
 
     public function failChain(string $batchId, int $failedIteration): void;

--- a/src/Messenger/Batch/BatchStoreInterface.php
+++ b/src/Messenger/Batch/BatchStoreInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Gems\Messenger\Batch;
+
+interface BatchStoreInterface
+{
+    public function count(string $batchId): int;
+    public function exists(string $batchId): bool;
+    public function getBatch(string $batchId): Batch|null;
+
+    public function getBatchIterationMessage(string $batchId, int $iteration): object|null;
+
+    public function isPending(string $batchId): bool;
+
+    public function isRunning(string $batchId): bool;
+
+    public function save(Batch $batch): void;
+
+    public function setIterationFinished(string $batchId, int $iteration): void;
+
+
+
+
+}

--- a/src/Messenger/Batch/DatabaseBatchStore.php
+++ b/src/Messenger/Batch/DatabaseBatchStore.php
@@ -77,7 +77,7 @@ class DatabaseBatchStore implements BatchStoreInterface
         return $this->resultFetcher->fetchOne('SELECT count(*) FROM gems__batch WHERE gba_id = ? AND gba_status = ?', [
             $batchId,
             BatchStatus::PENDING->value,
-        ]) > 1;
+        ]) > 0;
     }
 
     public function isRunning(string $batchId): bool
@@ -85,7 +85,7 @@ class DatabaseBatchStore implements BatchStoreInterface
         return $this->resultFetcher->fetchOne('SELECT count(*) FROM gems__batch WHERE gba_id = ? AND gba_status = ?', [
                 $batchId,
                 BatchStatus::RUNNING->value,
-            ]) > 1;
+            ]) > 0;
     }
 
     public function save(Batch $batch): void
@@ -118,11 +118,12 @@ class DatabaseBatchStore implements BatchStoreInterface
         return new Serializer($normalizers, $encoders);
     }
 
-    public function setIterationFinished(string $batchId, int $iteration): void
+    public function setIterationFinished(string $batchId, int $iteration, string|null $message = null): void
     {
         $this->resultFetcher->updateTable('gems__batch', [
             'gba_status' => BatchStatus::SUCCESS->value,
-            'gba_completed' => (new DateTimeImmutable())->format(self::DATETIME_STORAGE_FORMAT)
+            'gba_finished' => (new DateTimeImmutable())->format(self::DATETIME_STORAGE_FORMAT),
+            'gba_info' => $message,
         ], [
             'gba_id' => $batchId,
             'gba_iteration' => $iteration,
@@ -138,7 +139,7 @@ class DatabaseBatchStore implements BatchStoreInterface
 
         $this->resultFetcher->updateTable('gems__batch', [
             'gba_status' => $status->value,
-            'gba_completed' => $completed,
+            'gba_finished' => $completed,
             'gba_info' => $message,
         ], [
             'gba_id' => $batchId,

--- a/src/Messenger/Batch/DatabaseBatchStore.php
+++ b/src/Messenger/Batch/DatabaseBatchStore.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gems\Messenger\Batch;
+
+use DateTimeImmutable;
+use Exception;
+use Gems\Db\ResultFetcher;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
+use Symfony\Component\Serializer\Serializer;
+
+class DatabaseBatchStore implements BatchStoreInterface
+{
+    private const DATETIME_STORAGE_FORMAT = 'Y-m-d hH:i:s';
+
+    public function __construct(
+        private readonly ResultFetcher $resultFetcher,
+    )
+    {
+    }
+
+    public function count(string $batchId): int
+    {
+        return $this->resultFetcher->fetchOne('SELECT count(*) FROM gems__batch WHERE gba_id = ?', [$batchId]);
+    }
+
+    public function exists(string $batchId): bool
+    {
+        return $this->count($batchId) > 0;
+    }
+
+
+    public function getBatch(string $batchId): Batch|null
+    {
+        $data = $this->resultFetcher->fetchRow('SELECT * FROM gems__batch WHERE gba_id = ?', [$batchId]);
+
+        if (!$data) {
+            return null;
+        }
+
+        return new Batch(
+            $data['gba_id'],
+            new DateTimeImmutable($data['gba_created']),
+            $data['gba_name'],
+            $data['gba_group'],
+            $data['gba_finished'] ? new DateTimeImmutable($data['gba_finished']) : null,
+            BatchStatus::from($data['gba_status']),
+            (bool)$data['gba_chain'],
+        );
+    }
+
+    public function getBatchIterationMessage(string $batchId, int $iteration): object|null
+    {
+        $data = $this->resultFetcher->fetchRow('SELECT * FROM gems__batch WHERE gba_id = ? AND gba_iteration = ?', [$batchId, $iteration]);
+
+        if (!$data || !isset($data['gba_message'])) {
+            return null;
+        }
+
+        $serializer = $this->getSerializer();
+        try {
+            return $serializer->deserialize($data['gba_message'], $data['gba_messag_class'], 'json');
+        } catch(Exception $e) {
+            return null;
+        }
+    }
+
+    public function isPending(string $batchId): bool
+    {
+        return $this->resultFetcher->fetchRow('SELECT count(*) FROM gems__batch WHERE gba_id = ? AND gba_status = ?', [
+            $batchId,
+            BatchStatus::PENDING->value,
+        ]) > 1;
+    }
+
+    public function isRunning(string $batchId): bool
+    {
+        return $this->resultFetcher->fetchRow('SELECT count(*) FROM gems__batch WHERE gba_id = ? AND gba_status = ?', [
+                $batchId,
+                BatchStatus::RUNNING->value,
+            ]) > 1;
+    }
+
+    public function save(Batch $batch): void
+    {
+        $values = [
+            'gba_id' => $batch->batchId,
+            'gba_created' => $batch->created->format(self::DATETIME_STORAGE_FORMAT),
+            'gba_name' => $batch->name,
+            'gba_group' => $batch->group,
+            'gba_status' => $batch->status->value,
+        ];
+
+        $messages = $batch->getCurrentMessages();
+        $serializer = $this->getSerializer();
+
+        $i = $this->count($batch->batchId);
+        foreach($messages as $message) {
+            $i++ ;
+            $values['gba_iteration'] = $i;
+            $values['gba_message'] = $serializer->serialize($message, 'json');
+            $values['gba_message_class'] = $message::class;
+            $this->resultFetcher->insertIntoTable('gems__batch', $values);
+        }
+    }
+
+    private function getSerializer(): Serializer
+    {
+        $encoders = [new JsonEncoder()];
+        $normalizers = [new ObjectNormalizer()];
+        return new Serializer($normalizers, $encoders);
+    }
+
+    public function setIterationFinished(string $batchId, int $iteration): void
+    {
+        $this->resultFetcher->updateTable('gems__batch', [
+            'gba_status' => BatchStatus::SUCCESS,
+            'gba_completed' => (new DateTimeImmutable())->format(static::DATETIME_STORAGE_FORMAT)
+        ], [
+            'gba_id' => $batchId,
+            'gba_iteration' => $iteration,
+        ]);
+    }
+}

--- a/src/Messenger/Batch/DatabaseBatchStore.php
+++ b/src/Messenger/Batch/DatabaseBatchStore.php
@@ -133,16 +133,20 @@ class DatabaseBatchStore implements BatchStoreInterface
 
     public function setIterationStatus(string $batchId, int $iteration, BatchStatus $status, string|null $message = null): void
     {
-        $completed = null;
-        if ($status === BatchStatus::SUCCESS) {
-            $completed = (new DateTimeImmutable())->format(self::DATETIME_STORAGE_FORMAT);
+        $statusInfo = [
+            'gba_status' => $status->value,
+            'gba_info' => $message,
+        ];
+
+        if ($status === BatchStatus::RUNNING) {
+            $statusInfo['gba_started'] = (new DateTimeImmutable())->format(self::DATETIME_STORAGE_FORMAT);
         }
 
-        $this->resultFetcher->updateTable('gems__batch', [
-            'gba_status' => $status->value,
-            'gba_finished' => $completed,
-            'gba_info' => $message,
-        ], [
+        if ($status === BatchStatus::SUCCESS) {
+            $statusInfo['gba_finished'] = (new DateTimeImmutable())->format(self::DATETIME_STORAGE_FORMAT);
+        }
+
+        $this->resultFetcher->updateTable('gems__batch', $statusInfo, [
             'gba_id' => $batchId,
             'gba_iteration' => $iteration,
         ]);

--- a/src/Messenger/Batch/DatabaseBatchStore.php
+++ b/src/Messenger/Batch/DatabaseBatchStore.php
@@ -96,6 +96,7 @@ class DatabaseBatchStore implements BatchStoreInterface
             'gba_name' => $batch->name,
             'gba_group' => $batch->group,
             'gba_status' => $batch->status->value,
+            'gba_synchronous' => (int)$batch->isChain,
         ];
 
         $messages = $batch->getCurrentMessages();

--- a/src/Messenger/Batch/DatabaseBatchStore.php
+++ b/src/Messenger/Batch/DatabaseBatchStore.php
@@ -13,7 +13,7 @@ use Symfony\Component\Serializer\Serializer;
 
 class DatabaseBatchStore implements BatchStoreInterface
 {
-    private const DATETIME_STORAGE_FORMAT = 'Y-m-d hH:i:s';
+    private const DATETIME_STORAGE_FORMAT = 'Y-m-d H:i:s';
 
     public function __construct(
         private readonly ResultFetcher $resultFetcher,
@@ -69,7 +69,7 @@ class DatabaseBatchStore implements BatchStoreInterface
 
     public function isPending(string $batchId): bool
     {
-        return $this->resultFetcher->fetchRow('SELECT count(*) FROM gems__batch WHERE gba_id = ? AND gba_status = ?', [
+        return $this->resultFetcher->fetchOne('SELECT count(*) FROM gems__batch WHERE gba_id = ? AND gba_status = ?', [
             $batchId,
             BatchStatus::PENDING->value,
         ]) > 1;
@@ -77,7 +77,7 @@ class DatabaseBatchStore implements BatchStoreInterface
 
     public function isRunning(string $batchId): bool
     {
-        return $this->resultFetcher->fetchRow('SELECT count(*) FROM gems__batch WHERE gba_id = ? AND gba_status = ?', [
+        return $this->resultFetcher->fetchOne('SELECT count(*) FROM gems__batch WHERE gba_id = ? AND gba_status = ?', [
                 $batchId,
                 BatchStatus::RUNNING->value,
             ]) > 1;
@@ -117,7 +117,7 @@ class DatabaseBatchStore implements BatchStoreInterface
     {
         $this->resultFetcher->updateTable('gems__batch', [
             'gba_status' => BatchStatus::SUCCESS,
-            'gba_completed' => (new DateTimeImmutable())->format(static::DATETIME_STORAGE_FORMAT)
+            'gba_completed' => (new DateTimeImmutable())->format(self::DATETIME_STORAGE_FORMAT)
         ], [
             'gba_id' => $batchId,
             'gba_iteration' => $iteration,

--- a/src/Messenger/Batch/MessengerBatchRepository.php
+++ b/src/Messenger/Batch/MessengerBatchRepository.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gems\Messenger\Batch;
+
+use DateTimeImmutable;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Uid\Uuid;
+
+class MessengerBatchRepository
+{
+    public function __construct(
+        private readonly BatchStoreInterface $batchStore,
+        private readonly MessageBusInterface $messageBus,
+    )
+    {
+    }
+
+    public function createBatch(string|null $name = null, string|null $group = null, bool $isChain = false): Batch
+    {
+        $newId = Uuid::v4();
+
+        return new Batch(
+            batchId: $newId->toRfc4122(),
+            created: new DateTimeImmutable(),
+            name: $name,
+            group: $group,
+            isChain: $isChain,
+        );
+    }
+
+    public function getBatch(string $batchId): Batch|null
+    {
+        return $this->batchStore->getBatch($batchId);
+    }
+
+    public function getBatchIterationMessage(string $batchId, int $iteration): object|null
+    {
+        return $this->batchStore->getBatchIterationMessage($batchId, $iteration);
+    }
+
+    public function dispatch(Batch $batch): void
+    {
+        $this->batchStore->save($batch);
+
+        if (!count($batch->getCurrentMessages())) {
+            return;
+        }
+
+        if (!$batch->isChain) {
+            $this->dispatchMessages($batch->getCurrentMessages());
+            return;
+        }
+
+        if ($this->batchStore->isPending($batch->batchId) || !$this->batchStore->isRunning($batch->batchId)) {
+            $messages = $batch->getCurrentMessages();
+            $firstMessage = reset($messages);
+            $this->messageBus->dispatch($firstMessage);
+            return;
+        }
+    }
+
+    private function dispatchMessages(array $messages): void
+    {
+        foreach($messages as $message) {
+            $this->messageBus->dispatch($message);
+        }
+    }
+
+    public function setIterationFinished(string $batchId, int $iteration): void
+    {
+        $this->batchStore->setIterationFinished($batchId, $iteration);
+    }
+}

--- a/src/Messenger/Batch/MessengerBatchRepository.php
+++ b/src/Messenger/Batch/MessengerBatchRepository.php
@@ -63,6 +63,7 @@ class MessengerBatchRepository
 
         if (!$batch->isChain) {
             $this->dispatchMessages($batch->getCurrentMessages(), $batch->batchId, $currentCount);
+            $batch->clearMessages();
             return;
         }
 
@@ -70,6 +71,7 @@ class MessengerBatchRepository
             $messages = $batch->getCurrentMessages();
             $firstMessage = reset($messages);
             $this->dispatchMessages([$firstMessage], $batch->batchId, $currentCount);
+            $batch->clearMessages();
             return;
         }
     }

--- a/src/Messenger/Batch/MessengerBatchRunner.php
+++ b/src/Messenger/Batch/MessengerBatchRunner.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gems\Messenger\Batch;
+
+use Gems\Layout\LayoutSettings;
+use Laminas\Diactoros\Response\JsonResponse;
+use Mezzio\Helper\UrlHelper;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Zalt\Base\TranslatorInterface;
+use Zalt\Html\UrlArrayAttribute;
+
+class MessengerBatchRunner
+{
+    protected bool $autoStart = false;
+
+    protected string $formTitle = '';
+
+    protected null|string|array $jobInfo = null;
+
+    protected string $progressParameterName = 'progress';
+
+    public function __construct(
+        protected readonly Batch $batch,
+        protected readonly object|array|string $batchMessageLoader,
+        protected readonly MessengerBatchRepository $messengerBatchRepository,
+        protected readonly TranslatorInterface $translator,
+        protected readonly LayoutSettings $layoutSettings,
+        protected readonly UrlHelper $urlHelper,
+        array $config,
+    )
+    {
+        $this->vueSettings = $config['vue'] ?? [];
+    }
+
+    protected function getInitResponse(): ResponseInterface
+    {
+        $data = [
+            'translations' => [
+                'cancel' => $this->translator->_('Cancel'),
+                'restart' => $this->translator->_('Restart'),
+                'start' => $this->translator->_('Start jobs'),
+                'empty' => $this->translator->_('No tasks to do'),
+            ],
+            'info' => $this->jobInfo,
+        ];
+        return new JsonResponse($data);
+    }
+
+    protected function getJsAttributes(): array
+    {
+        $output[':autostart']  = $this->autoStart ? 'true' : 'false';
+        $output['init-url']    = $this->getUrl('init');
+        $output['run-url']     = $this->getUrl('run');
+        $output['restart-url'] = $this->getUrl('restart');
+
+        return $output;
+    }
+
+    protected function getStartResponse(): ResponseInterface
+    {
+        if ($this->batch->totalItems === null) {
+            // Initialize with loader and dispatch!
+            $this->loadItems();
+        }
+
+        return $this->reportProgress();
+    }
+
+    public function getResponse(ServerRequestInterface $request): ?ResponseInterface
+    {
+        $queryParams = $request->getQueryParams();
+        if (isset($queryParams[$this->progressParameterName])) {
+            $response = match($queryParams[$this->progressParameterName]) {
+                'init' => $this->getInitResponse(),
+                'start' => $this->getStartResponse(),
+                'run' => $this->getRunResponse(),
+                'restart' => $this->getRestartResponse(),
+                default => null,
+            };
+
+            if ($response instanceof ResponseInterface) {
+                return $response;
+            }
+        }
+
+
+        $this->layoutSettings->addVue($this->vueSettings);
+        $this->layoutSettings->disableIdleCheck();
+        $attributes = $this->getJsAttributes();
+        $attributes['title'] = $this->getTitle();
+        $this->layoutSettings->addLayoutParameter('tag', 'batch-runner')
+            ->addLayoutParameter('attributes', $attributes);
+
+        return null;
+    }
+
+    protected function getRestartResponse(): ResponseInterface
+    {
+
+        return $this->getRunResponse();
+    }
+
+    protected function getRunResponse(): ResponseInterface
+    {
+        return $this->reportProgress();
+    }
+
+    protected function getTitle(): ?string
+    {
+        return $this->formTitle;
+    }
+
+    protected function getUrl(string $progress): string
+    {
+        return UrlArrayAttribute::toUrlString([$this->urlHelper->getBasePath()] + [$this->progressParameterName => $progress]);
+    }
+
+    protected function loadItems(): void
+    {
+        if (is_callable($this->batchMessageLoader)) {
+            call_user_func_array($this->batchMessageLoader, [$this->batch]);
+            return;
+        }
+        if (is_array($this->batchMessageLoader)) {
+            $this->batch->addMessages($this->batchMessageLoader);
+            return;
+        }
+    }
+
+    protected function reportProgress(): ResponseInterface
+    {
+        $data = [
+            'count' => $this->batch->totalItems,
+            'percent' => $this->batch->getPercent(),
+            'messages' => $this->messengerBatchRepository->getBatchInfoList($this->batch->batchId),
+            'finished' => $this->batch->totalItems === $this->batch->success,
+        ];
+
+        return new JsonResponse($data);
+    }
+
+    /**
+     * @param array|string|null $jobInfo
+     */
+    public function setJobInfo(array|string|null $jobInfo): void
+    {
+        $this->jobInfo = $jobInfo;
+    }
+
+
+}

--- a/src/Messenger/MessengerFactory.php
+++ b/src/Messenger/MessengerFactory.php
@@ -4,6 +4,8 @@ namespace Gems\Messenger;
 
 
 use Gems\Legacy\CurrentUserRepository;
+use Gems\Messenger\Batch\BatchMiddleware;
+use Gems\Messenger\Batch\MessengerBatchRepository;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use Psr\Container\ContainerInterface;
 use Psr\EventDispatcher\EventDispatcherInterface;
@@ -60,6 +62,7 @@ class MessengerFactory implements FactoryInterface
         }
 
         $middleware = [
+            new BatchMiddleware($container->get(MessengerBatchRepository::class), $container),
             new CurrentUserMiddleware($container->get(CurrentUserRepository::class)),
             new AddBusNameStampMiddleware($this->busName),
             new RejectRedeliveredMessageMiddleware(),

--- a/src/Messenger/MessengerFactory.php
+++ b/src/Messenger/MessengerFactory.php
@@ -62,7 +62,7 @@ class MessengerFactory implements FactoryInterface
         }
 
         $middleware = [
-            new BatchMiddleware($container->get(MessengerBatchRepository::class), $container),
+            new BatchMiddleware($container),
             new CurrentUserMiddleware($container->get(CurrentUserRepository::class)),
             new AddBusNameStampMiddleware($this->busName),
             new RejectRedeliveredMessageMiddleware(),

--- a/tests/Messenger/Batch/BatchMiddlewareTest.php
+++ b/tests/Messenger/Batch/BatchMiddlewareTest.php
@@ -48,8 +48,9 @@ class BatchMiddlewareTest extends DatabaseTestCase
         $container = $this->createMock(ContainerInterface::class);
         $container->method('get')->with(MessageBusInterface::class)->willReturn($messageBus);
         $repository = $this->getBatchRepository();
+        $container->method('get')->with(MessengerBatchRepository::class)->willReturn($repository);
 
-        return new BatchMiddleware($repository, $container);
+        return new BatchMiddleware($container);
     }
 
     private function getStack(): StackInterface
@@ -180,7 +181,9 @@ class BatchMiddlewareTest extends DatabaseTestCase
 
         $stack = new StackMiddleware($failingMiddleware);
 
-        $middleware = new BatchMiddleware($batchRepository, $this->createStub(ContainerInterface::class));
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')->with(MessengerBatchRepository::class)->willReturn($batchRepository);
+        $middleware = new BatchMiddleware($container);
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Error!');

--- a/tests/Messenger/Batch/BatchMiddlewareTest.php
+++ b/tests/Messenger/Batch/BatchMiddlewareTest.php
@@ -45,11 +45,18 @@ class BatchMiddlewareTest extends DatabaseTestCase
             $messageBus = new MessageBus();
         }
 
-        $container = $this->createMock(ContainerInterface::class);
-        $container->method('get')->with(MessageBusInterface::class)->willReturn($messageBus);
         $repository = $this->getBatchRepository();
-        $container->method('get')->with(MessengerBatchRepository::class)->willReturn($repository);
 
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')->willReturnCallback(function (string $className) use ($messageBus, $repository) {
+            if ($className === MessageBusInterface::class) {
+                return $messageBus;
+            }
+            if ($className === MessengerBatchRepository::class) {
+                return $repository;
+            }
+            return null;
+        });
         return new BatchMiddleware($container);
     }
 

--- a/tests/Messenger/Batch/BatchMiddlewareTest.php
+++ b/tests/Messenger/Batch/BatchMiddlewareTest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GemsTest\Messenger\Batch;
+
+use Gems\Messenger\Batch\BatchMiddleware;
+use Gems\Messenger\Batch\BatchStamp;
+use Gems\Messenger\Batch\BatchStatus;
+use Gems\Messenger\Batch\DatabaseBatchStore;
+use Gems\Messenger\Batch\MessengerBatchRepository;
+use GemsTest\testUtils\DatabaseTestCase;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBus;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
+use Symfony\Component\Messenger\Middleware\StackInterface;
+use Symfony\Component\Messenger\Middleware\StackMiddleware;
+use Symfony\Component\Messenger\Stamp\HandledStamp;
+
+class BatchMiddlewareTest extends DatabaseTestCase
+{
+    protected array $dbTables = [
+        'gems__batch',
+    ];
+
+    private MessengerBatchRepository|null $repository = null;
+
+    private function getBatchRepository(): MessengerBatchRepository
+    {
+        if (!$this->repository) {
+            $this->repository = new MessengerBatchRepository(
+                new DatabaseBatchStore($this->resultFetcher),
+                new MessageBus(),
+            );
+        }
+
+        return $this->repository;
+    }
+
+    private function getMiddleware(MessageBusInterface|null $messageBus = null): BatchMiddleware
+    {
+        if ($messageBus === null) {
+            $messageBus = new MessageBus();
+        }
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')->with(MessageBusInterface::class)->willReturn($messageBus);
+        $repository = $this->getBatchRepository();
+
+        return new BatchMiddleware($repository, $container);
+    }
+
+    private function getStack(): StackInterface
+    {
+        $handler = new class {
+            public function __invoke(TestMessage $testMessage): string
+            {
+                return $testMessage->name;
+            }
+        };
+        $next = new class($handler) implements MiddlewareInterface {
+            public function __construct(private $handler) {}
+
+            public function handle(Envelope $envelope, StackInterface $stack): Envelope
+            {
+                $result = ($this->handler)($envelope->getMessage());
+                return $envelope->with(new HandledStamp(
+                    $result,
+                    get_class($this->handler)
+                ));
+            }
+        };
+
+        // Wrap it in a StackMiddleware so it behaves like Messenger’s stack
+        return new StackMiddleware([$next]);
+    }
+
+    public function testNoChain(): void
+    {
+        $store = new DatabaseBatchStore($this->resultFetcher);
+        $repository = $this->getBatchRepository();
+        $batch = $repository->createBatch();
+
+        $messages = [
+            new TestMessage('test123'),
+            new TestMessage('test456'),
+        ];
+
+        $batch->addMessages($messages);
+
+        $store->save($batch);
+
+        $messageBus = $this->createMock(MessageBusInterface::class);
+        $messageBus->expects($this->never())->method('dispatch');
+
+        $middleware = $this->getMiddleware($messageBus);
+
+        $envelope = Envelope::wrap($messages[0], [new BatchStamp($batch->batchId, 1)]);
+
+        $middleware->handle($envelope, $this->getStack());
+    }
+
+    public function testChain(): void
+    {
+        $store = new DatabaseBatchStore($this->resultFetcher);
+        $repository = $this->getBatchRepository();
+        $batch = $repository->createBatch(isChain: true);
+
+        $messages = [
+            new TestMessage('test123'),
+            new TestMessage('test456'),
+        ];
+
+        $batch->addMessages($messages);
+
+        $store->save($batch);
+
+        $capturedEnvelopes = [];
+        $messageBus = $this->createMock(MessageBus::class);
+        $messageBus
+            ->expects($this->once())->method('dispatch')
+            ->willReturnCallback(function (object $message, array $stamps = []) use (&$capturedEnvelopes) {
+                // If code passed a raw message, wrap it similarly to real bus behavior:
+                $envelope = Envelope::wrap($message, $stamps);
+                $capturedEnvelopes[] = $envelope;
+                return $envelope;
+            });
+
+        $middleware = $this->getMiddleware($messageBus);
+
+        $envelope = Envelope::wrap($messages[0], [new BatchStamp($batch->batchId, 1)]);
+
+        $middleware->handle($envelope, $this->getStack());
+
+        $this->assertCount(1, $capturedEnvelopes);
+        $stamp = $capturedEnvelopes[0]->last(BatchStamp::class);
+        $this->assertInstanceOf(BatchStamp::class, $stamp);
+        $this->assertEquals(2, $stamp->iteration);
+        $message = $capturedEnvelopes[0]->getMessage();
+        $this->assertEquals('test456', $message->name);
+    }
+
+    public function testItMarksBatchAsFailedOnException()
+    {
+        $batchId = 'batch-123';
+        $iteration = 1;
+
+        $envelope = (new Envelope(new TestMessage('test123')))
+            ->with(new BatchStamp($batchId, $iteration));
+
+        $matcher = $this->exactly(2);
+        $batchRepository = $this->createMock(MessengerBatchRepository::class);
+        $batchRepository->expects($matcher)
+            ->method('setIterationStatus')
+            ->willReturnCallback(function ($batchId, $iteration, $status, $message = null) use ($matcher) {
+                switch ($matcher->numberOfInvocations()) {
+                    case 1:
+                        $this->assertSame('batch-123', $batchId);
+                        $this->assertSame(1, $iteration);
+                        $this->assertSame(BatchStatus::RUNNING, $status);
+                        break;
+                    case 2:
+                        $this->assertSame('batch-123', $batchId);
+                        $this->assertSame(1, $iteration);
+                        $this->assertSame(BatchStatus::FAILED, $status);
+                        $this->assertStringContainsString('Error', $message);
+                        break;
+                }
+            });
+
+        // Fake "next" middleware that throws
+        $failingMiddleware = new class implements MiddlewareInterface {
+            public function handle(Envelope $envelope, StackInterface $stack): Envelope
+            {
+                throw new \RuntimeException('Error!');
+            }
+        };
+
+        $stack = new StackMiddleware($failingMiddleware);
+
+        $middleware = new BatchMiddleware($batchRepository, $this->createStub(ContainerInterface::class));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Error!');
+
+        $middleware->handle($envelope, $stack);
+    }
+}

--- a/tests/Messenger/Batch/DatabaseBatchStoreTest.php
+++ b/tests/Messenger/Batch/DatabaseBatchStoreTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace GemsTest\Messenger\Batch;
+
+use DateTimeImmutable;
+use Gems\Messenger\Batch\Batch;
+use Gems\Messenger\Batch\DatabaseBatchStore;
+use GemsTest\testUtils\DatabaseTestCase;
+
+class DatabaseBatchStoreTest extends DatabaseTestCase
+{
+    protected array $dbTables = [
+        'gems__batch',
+    ];
+
+    private function getStore(): DatabaseBatchStore
+    {
+        return new DatabaseBatchStore($this->resultFetcher);
+    }
+
+    public function testSave(): void
+    {
+        $batchId = '550e8400-e29b-41d4-a716-446655440000';
+
+        $store = $this->getStore();
+        $count = $store->count($batchId);
+        $this->assertEquals(0, $count);
+
+        $batch = new Batch(
+            batchId: $batchId,
+            created: new DateTimeImmutable(),
+        );
+        $batch->addMessage(new TestMessage('test123'));
+        $store->save($batch);
+
+        $count = $store->count($batchId);
+        $this->assertEquals(1, $count);
+
+        $this->assertTrue($store->exists($batchId));
+    }
+
+    public function testGetBatchIterationMessage(): void
+    {
+        $batchId = '550e8400-e29b-41d4-a716-446655440000';
+
+        $store = $this->getStore();
+
+        $batch = new Batch(
+            batchId: $batchId,
+            created: new DateTimeImmutable(),
+        );
+        $batch->addMessage(new TestMessage('test123'));
+        $store->save($batch);
+
+        $message = $store->getBatchIterationMessage($batchId, 1);
+
+        $this->assertInstanceOf(TestMessage::class, $message);
+
+        $this->assertEquals('test123', $message->name);
+    }
+
+
+}

--- a/tests/Messenger/Batch/DatabaseBatchStoreTest.php
+++ b/tests/Messenger/Batch/DatabaseBatchStoreTest.php
@@ -125,7 +125,7 @@ class DatabaseBatchStoreTest extends DatabaseTestCase
         ]);
         $store->save($batch);
 
-        $this->assertTrue($store->isPending($batchId));
+        $this->assertTrue($store->hasPending($batchId));
 
         $store->setIterationStatus($batchId, 1, BatchStatus::RUNNING);
 

--- a/tests/Messenger/Batch/MessengerBatchRepositoryTest.php
+++ b/tests/Messenger/Batch/MessengerBatchRepositoryTest.php
@@ -2,9 +2,11 @@
 
 namespace GemsTest\Messenger\Batch;
 
+use Gems\Messenger\Batch\BatchStamp;
 use Gems\Messenger\Batch\DatabaseBatchStore;
 use Gems\Messenger\Batch\MessengerBatchRepository;
 use GemsTest\testUtils\DatabaseTestCase;
+use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBus;
 
 class MessengerBatchRepositoryTest extends DatabaseTestCase
@@ -18,7 +20,6 @@ class MessengerBatchRepositoryTest extends DatabaseTestCase
         $batchStore = new DatabaseBatchStore($this->resultFetcher);
 
         $messengerBus = new MessageBus();
-
 
         return new MessengerBatchRepository($batchStore, $messengerBus);
     }
@@ -43,7 +44,113 @@ class MessengerBatchRepositoryTest extends DatabaseTestCase
 
         $result = $repository->count($batch->batchId);
         $this->assertEquals(1, $result);
+    }
 
+    public function testAsyncDispatch(): void
+    {
+        $batchStore = new DatabaseBatchStore($this->resultFetcher);
 
+        $capturedEnvelopes = [];
+
+        $messengerBus = $this->createMock(MessageBus::class);
+        $messengerBus
+            ->method('dispatch')
+            ->willReturnCallback(function (object $message, array $stamps = []) use (&$capturedEnvelopes) {
+                // If code passed a raw message, wrap it similarly to real bus behavior:
+                $envelope = Envelope::wrap($message, $stamps);
+                $capturedEnvelopes[] = $envelope;
+                return $envelope;
+            });
+
+        $repository = new MessengerBatchRepository($batchStore, $messengerBus);
+        $batch = $repository->createBatch('testBatch');
+
+        $batch->addMessages([
+            new TestMessage('test123'),
+            new TestMessage('test456'),
+        ]);
+
+        $repository->dispatch($batch);
+
+        $this->assertCount(2, $capturedEnvelopes);
+        $stamp = $capturedEnvelopes[0]->last(BatchStamp::class);
+        $this->assertInstanceOf(BatchStamp::class, $stamp);
+        $this->assertEquals(1, $stamp->iteration);
+        $message = $capturedEnvelopes[0]->getMessage();
+        $this->assertEquals('test123', $message->name);
+
+        $stamp = $capturedEnvelopes[1]->last(BatchStamp::class);
+        $this->assertInstanceOf(BatchStamp::class, $stamp);
+        $this->assertEquals(2, $stamp->iteration);
+        $message = $capturedEnvelopes[1]->getMessage();
+        $this->assertEquals('test456', $message->name);
+    }
+
+    public function testSyncDispatch(): void
+    {
+        $batchStore = new DatabaseBatchStore($this->resultFetcher);
+
+        $capturedEnvelopes = [];
+
+        $messengerBus = $this->createMock(MessageBus::class);
+        $messengerBus
+            ->method('dispatch')
+            ->willReturnCallback(function ($arg) use (&$capturedEnvelopes) {
+                // If code passed a raw message, wrap it similarly to real bus behavior:
+                $envelope = $arg instanceof Envelope ? $arg : new Envelope($arg);
+                $capturedEnvelopes[] = $envelope;
+                return $envelope;
+            });
+
+        $repository = new MessengerBatchRepository($batchStore, $messengerBus);
+        $batch = $repository->createBatch('testBatch', isChain: true);
+
+        $batch->addMessages([
+            new TestMessage('test123'),
+            new TestMessage('test456'),
+        ]);
+
+        $repository->dispatch($batch);
+
+        $this->assertCount(1, $capturedEnvelopes);
+    }
+
+    public function testAsyncMultiDispatch(): void
+    {
+        $batchStore = new DatabaseBatchStore($this->resultFetcher);
+
+        $capturedEnvelopes = [];
+
+        $messengerBus = $this->createMock(MessageBus::class);
+        $messengerBus
+            ->method('dispatch')
+            ->willReturnCallback(function (object $message, array $stamps = []) use (&$capturedEnvelopes) {
+                // If code passed a raw message, wrap it similarly to real bus behavior:
+                $envelope = Envelope::wrap($message, $stamps);
+                $capturedEnvelopes[] = $envelope;
+                return $envelope;
+            });
+
+        $repository = new MessengerBatchRepository($batchStore, $messengerBus);
+        $batch = $repository->createBatch('testBatch');
+
+        $batch->addMessage(new TestMessage('test123'));
+        $repository->dispatch($batch);
+
+        $batch->addMessage(new TestMessage('test456'));
+        $repository->dispatch($batch);
+
+        $this->assertCount(2, $capturedEnvelopes);
+        $stamp = $capturedEnvelopes[0]->last(BatchStamp::class);
+        $this->assertInstanceOf(BatchStamp::class, $stamp);
+        $this->assertEquals(1, $stamp->iteration);
+        $message = $capturedEnvelopes[0]->getMessage();
+        $this->assertEquals('test123', $message->name);
+
+        $stamp = $capturedEnvelopes[1]->last(BatchStamp::class);
+        $this->assertInstanceOf(BatchStamp::class, $stamp);
+        $this->assertEquals(2, $stamp->iteration);
+        $message = $capturedEnvelopes[1]->getMessage();
+        $this->assertEquals('test456', $message->name);
     }
 }

--- a/tests/Messenger/Batch/MessengerBatchRepositoryTest.php
+++ b/tests/Messenger/Batch/MessengerBatchRepositoryTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace GemsTest\Messenger\Batch;
+
+use Gems\Messenger\Batch\DatabaseBatchStore;
+use Gems\Messenger\Batch\MessengerBatchRepository;
+use GemsTest\testUtils\DatabaseTestCase;
+use Symfony\Component\Messenger\MessageBus;
+
+class MessengerBatchRepositoryTest extends DatabaseTestCase
+{
+    protected array $dbTables = [
+        'gems__batch',
+    ];
+
+    private function getRepository(): MessengerBatchRepository
+    {
+        $batchStore = new DatabaseBatchStore($this->resultFetcher);
+
+        $messengerBus = new MessageBus();
+
+
+        return new MessengerBatchRepository($batchStore, $messengerBus);
+    }
+
+    public function testCreateBatch(): void
+    {
+        $repository = $this->getRepository();
+        $batch = $repository->createBatch('testBatch');
+
+        $this->assertEquals('testBatch', $batch->name);
+        $this->assertEquals(36, strlen($batch->batchId));
+    }
+
+    public function testSaveBatch(): void
+    {
+        $repository = $this->getRepository();
+        $batch = $repository->createBatch('testBatch');
+
+        $batch->addMessage(new TestMessage('hi'));
+
+        $repository->dispatch($batch);
+
+        $result = $repository->count($batch->batchId);
+        $this->assertEquals(1, $result);
+
+
+    }
+}

--- a/tests/Messenger/Batch/MessengerBatchRepositoryTest.php
+++ b/tests/Messenger/Batch/MessengerBatchRepositoryTest.php
@@ -50,6 +50,7 @@ class MessengerBatchRepositoryTest extends DatabaseTestCase
     {
         $batchStore = new DatabaseBatchStore($this->resultFetcher);
 
+        /** @var list<Envelope> $capturedEnvelopes */
         $capturedEnvelopes = [];
 
         $messengerBus = $this->createMock(MessageBus::class);
@@ -91,6 +92,7 @@ class MessengerBatchRepositoryTest extends DatabaseTestCase
     {
         $batchStore = new DatabaseBatchStore($this->resultFetcher);
 
+        /** @var list<Envelope> $capturedEnvelopes */
         $capturedEnvelopes = [];
 
         $messengerBus = $this->createMock(MessageBus::class);
@@ -120,6 +122,7 @@ class MessengerBatchRepositoryTest extends DatabaseTestCase
     {
         $batchStore = new DatabaseBatchStore($this->resultFetcher);
 
+        /** @var list<Envelope> $capturedEnvelopes */
         $capturedEnvelopes = [];
 
         $messengerBus = $this->createMock(MessageBus::class);

--- a/tests/Messenger/Batch/MessengerBatchRepositoryTest.php
+++ b/tests/Messenger/Batch/MessengerBatchRepositoryTest.php
@@ -79,6 +79,7 @@ class MessengerBatchRepositoryTest extends DatabaseTestCase
         $message = $capturedEnvelopes[0]->getMessage();
         $this->assertEquals('test123', $message->name);
 
+        assert(isset($capturedEnvelopes[1]));
         $stamp = $capturedEnvelopes[1]->last(BatchStamp::class);
         $this->assertInstanceOf(BatchStamp::class, $stamp);
         $this->assertEquals(2, $stamp->iteration);
@@ -147,6 +148,8 @@ class MessengerBatchRepositoryTest extends DatabaseTestCase
         $message = $capturedEnvelopes[0]->getMessage();
         $this->assertEquals('test123', $message->name);
 
+
+        assert(isset($capturedEnvelopes[1]));
         $stamp = $capturedEnvelopes[1]->last(BatchStamp::class);
         $this->assertInstanceOf(BatchStamp::class, $stamp);
         $this->assertEquals(2, $stamp->iteration);

--- a/tests/Messenger/Batch/TestMessage.php
+++ b/tests/Messenger/Batch/TestMessage.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace GemsTest\Messenger\Batch;
+
+class TestMessage
+{
+    public function __construct(
+        public readonly string $name,
+    )
+    {
+    }
+}


### PR DESCRIPTION
Add batched messaging support, to track and chain message queue messages.
In RunCommJob chaining messages is required when async processing is turned on, or the execution order will not be correct.
This does lose the interactive console logging during the run, only after every job is complete will it report. 