### PR TITLE
Support a combination of POST and GET parameters in embed login

### DIFF
--- a/src/Handlers/Auth/EmbedLoginHandler.php
+++ b/src/Handlers/Auth/EmbedLoginHandler.php
@@ -73,7 +73,10 @@ class EmbedLoginHandler implements RequestHandlerInterface
             $session = $request->getAttribute(SessionInterface::class);
             $authenticationService = $this->authenticationServiceBuilder->buildAuthenticationService($session);
 
-            $input = ($request->getMethod() === 'POST') ? $request->getParsedBody() : $request->getQueryParams();
+            $input = $request->getQueryParams();
+            if ($request->getMethod() === 'POST') {
+                $input = array_merge($input, $request->getParsedBody() ?? []);
+            }
 
             $result = null;
 


### PR DESCRIPTION
This allows us to use POST for the sensitive parameters, such as the key and username.