### PR TITLE
Preserve flash messages in logout handler

### DIFF
--- a/src/Handlers/Auth/LogoutHandler.php
+++ b/src/Handlers/Auth/LogoutHandler.php
@@ -9,12 +9,15 @@ use Gems\AuthNew\AuthenticationMiddleware;
 use Gems\AuthNew\AuthenticationServiceBuilder;
 use Gems\AuthTfa\OtpMethodBuilder;
 use Gems\AuthTfa\TfaService;
+use Gems\Middleware\FlashMessageMiddleware;
 use Laminas\Diactoros\Response\RedirectResponse;
 use Mezzio\Helper\UrlHelper;
 use Mezzio\Session\SessionInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use Zalt\Message\MessageStatus;
+use Zalt\Message\StatusMessengerInterface;
 
 class LogoutHandler implements RequestHandlerInterface
 {
@@ -39,12 +42,57 @@ class LogoutHandler implements RequestHandlerInterface
         $session = $request->getAttribute(SessionInterface::class);
         $authenticationService = $this->authenticationServiceBuilder->buildAuthenticationService($session);
         $tfaService = new TfaService($session, $authenticationService, $this->otpMethodBuilder);
+        /** @var StatusMessengerInterface|null $statusMessenger */
+        $statusMessenger = $request->getAttribute(FlashMessageMiddleware::STATUS_MESSENGER_ATTRIBUTE);
+
+        $messages = [];
+        if ($statusMessenger) {
+            $messages = $this->getMessages($statusMessenger);
+        }
 
         $tfaService->logout();
         $authenticationService->logout();
 
         $session->clear();
 
+        if ($statusMessenger) {
+            $this->putMessages($statusMessenger, $messages);
+        }
+
         return new RedirectResponse($this->urlHelper->generate('auth.login'));
+    }
+
+    /**
+     * Get current flash messages from the session.
+     */
+    private function getMessages(StatusMessengerInterface $statusMessenger): array
+    {
+        $dangerMessages = $statusMessenger->getMessages(MessageStatus::Danger);
+        $infoMessages = $statusMessenger->getMessages(MessageStatus::Info);
+        $warningMessages = $statusMessenger->getMessages(MessageStatus::Warning);
+        $successMessages = $statusMessenger->getMessages(MessageStatus::Success);
+
+        return [$dangerMessages, $infoMessages, $warningMessages, $successMessages];
+    }
+
+    /**
+     * Put flash messages back into the session.
+     */
+    private function putMessages(StatusMessengerInterface $statusMessenger, array $messages): void
+    {
+        [$dangerMessages, $infoMessages, $warningMessages, $successMessages] = $messages;
+
+        if (!empty($dangerMessages)) {
+            $statusMessenger->addMessages($dangerMessages, MessageStatus::Danger);
+        }
+        if (!empty($infoMessages)) {
+            $statusMessenger->addMessages($infoMessages, MessageStatus::Info);
+        }
+        if (!empty($warningMessages)) {
+            $statusMessenger->addMessages($warningMessages, MessageStatus::Warning);
+        }
+        if (!empty($successMessages)) {
+            $statusMessenger->addMessages($successMessages, MessageStatus::Success);
+        }
     }
 }


### PR DESCRIPTION
This fixes a problem which happens in the Embed Login functionality, and possibly in other cases as well. If, during embed login, the patient is not found, a flash message is set, and a redirect to the logout route is issued. The logout handler clears the session and redirects to the login page. The flash messages are therefore never shown.

Since there is no way to get all messages with the correct message type, this unfortunately is a bit convoluted.