### PR TITLE
Update auto configurator to use the (already existing but now fixed) …

### DIFF
--- a/src/Config/AutoConfig/EventListeners.php
+++ b/src/Config/AutoConfig/EventListeners.php
@@ -97,7 +97,7 @@ class EventListeners implements AutoConfigInterface
         }
 
         foreach((array)$events as $event) {
-            $newConfig['events']['listeners'][$event] = [$listener, $priority];
+            $newConfig['events']['listeners'][$event][] = [$listener, $priority];
         }
 
         return $newConfig;

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -19,6 +19,7 @@ use Gems\Condition\Comparator\ComparatorAbstract;
 use Gems\Condition\RoundConditionInterface;
 use Gems\Condition\TrackConditionInterface;
 use Gems\Config\App;
+use Gems\Config\AutoConfig\EventListeners;
 use Gems\Config\AutoConfig\MessageHandlers;
 use Gems\Config\Messenger;
 use Gems\Config\Route;
@@ -107,6 +108,7 @@ use Mezzio\Session\SessionPersistenceInterface;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LogLevel;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
@@ -322,6 +324,7 @@ class ConfigProvider
                     AsCommand::class => ['config' => 'console.commands'],
                     AsMessageHandler::class => MessageHandlers::class,
                     AsStreamLogger::class => AutoConfigAttributeLogger::class,
+                    AsEventListener::class => EventListeners::class,
                 ],
             ],
         ];

--- a/src/Factory/EventDispatcherFactory.php
+++ b/src/Factory/EventDispatcherFactory.php
@@ -31,12 +31,23 @@ class EventDispatcherFactory implements FactoryInterface
             if (isset($config['events']['listeners'])) {
                 foreach($config['events']['listeners'] as $eventName => $listeners) {
                     foreach((array)$listeners as $listener) {
-                        if (is_string($listener)) {
-                            $event->addListener($eventName, $listener);
-                            continue;
+                        $listenerCallable = $listener;
+                        $priority = 0;
+                        if (is_array($listener)) {
+                            list($listenerCallable, $priority) = $listener;
                         }
-                        // Assume array with listener callable and priority
-                        $event->addListener($eventName, $listener[0], $listener[1]);
+
+                        if (is_string($listenerCallable)) {
+                            if (class_exists($listenerCallable)) {
+                                $listenerClass = $container->get($listenerCallable);
+                                $event->addListener($eventName, $listenerClass, $priority);
+                                continue;
+                            }
+                            if (is_callable($listenerCallable)) {
+                                $event->addListener($eventName, $listenerCallable, $priority);
+                                continue;
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
…EventListener auto config, and fix separate adding of event listeners from config

This makes it possible to add Event Listener classes, instead of always using EventSubscribers. E.g:
```PHP
#[AsEventListener]
class MyEventListener
{
    public function __invoke(MyEvent $event): void
    {
        // Do something with the event
    }
}
```