### PR TITLE
Restored export survey settings workings

### DIFF
--- a/src/Config/Menu.php
+++ b/src/Config/Menu.php
@@ -1662,6 +1662,11 @@ class Menu
                             'type' => 'route-link-item',
                         ],
                         [
+                            'name' => 'track-builder.survey-maintenance.export-settings',
+                            'label' => $this->translator->trans('Export settings'),
+                            'type' => 'route-link-item',
+                        ],
+                        [
                             'name' => 'track-builder.survey-maintenance.update-survey.run',
                             'label' => $this->translator->trans('Update to new survey'),
                             'type' => 'route-link-item',

--- a/src/Config/Route.php
+++ b/src/Config/Route.php
@@ -1418,12 +1418,17 @@ class Route
                     'attributes',
                     'check',
                     'answer-import',
+                    'export-settings'
                 ],
                 parameterRoutes: [
                     ...$this->defaultParameterRoutes,
                     'check',
                     'answer-import',
                     'attributes',
+                ],
+                postRoutes: [
+                    ...$this->defaultPostRoutes,
+                    'export-settings',
                 ],
             ),
             ...$this->createSnippetRoutes(baseName: 'track-builder.survey-maintenance.update-survey',

--- a/src/Export/Db/DbExportRepository.php
+++ b/src/Export/Db/DbExportRepository.php
@@ -164,7 +164,7 @@ class DbExportRepository
 
     public function getExportResult(string $exportId, int $userId): StatementInterface|ResultSet|null
     {
-        $select = $this->unbufferedResultFetcher->getSelect('gems__file_exports')
+        $select = $this->resultFetcher->getSelect('gems__file_exports')
             ->columns(['gfex_data', 'gfex_file_name', 'gfex_schema_name', 'gfex_export_type', 'gfex_export_settings', 'gfex_column_order', 'gfex_row_count'])
             ->where([
                 'gfex_export_id' => $exportId,
@@ -172,7 +172,7 @@ class DbExportRepository
             ])
             ->order(['gfex_schema_name', 'gfex_order']);
 
-        return $this->unbufferedResultFetcher->query($select);
+        return $this->resultFetcher->query($select);
     }
 
     protected function getExportTypeClassName(string $exportType): string|null

--- a/src/Export/Export.php
+++ b/src/Export/Export.php
@@ -19,6 +19,7 @@ class Export
         'SpssExport' => 'SPSS',
         'CsvExport' => 'CSV',
         //'StreamingStataExport' => 'Stata (xml)',
+        'TextExport' => 'Text',
     ];
 
     protected array $streamingExportClasses = [

--- a/src/Export/Type/ExportAbstract.php
+++ b/src/Export/Type/ExportAbstract.php
@@ -4,6 +4,7 @@ namespace Gems\Export\Type;
 
 use DateTimeInterface;
 use Gems\Html;
+use Zalt\File\File;
 use Zalt\Base\TranslatorInterface;
 use Zalt\Html\AElement;
 use Zalt\Html\ElementInterface;
@@ -27,6 +28,8 @@ abstract class ExportAbstract implements ExportInterface
     )
     {
         $this->tempExportDir = $config['export']['tempExportDir'] ?? 'data/export/';
+
+        File::ensureDir($this->tempExportDir);
     }
 
     /**

--- a/src/Export/Type/TextExport.php
+++ b/src/Export/Type/TextExport.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @package    Gems
+ * @subpackage Export
+ * @author     Matijs de Jong <mjong@magnafacta.nl>
+ */
+
+namespace Gems\Export\Type;
+
+use Gems\Export\Db\DataExtractorInterface;
+use Iterator;
+use MUtil\Form;
+
+/**
+ * @package    Gems
+ * @subpackage Export
+ * @since      Class available since version 1.0
+ */
+class TextExport extends ExportAbstract implements DownloadableInterface, ExportSettingsGeneratorInterface
+{
+    public const EXTENSION = 'txt';
+
+    /**
+     * Delimiter used for text export
+     * @var string
+     */
+    protected $delimiter = "\t";
+
+    /**
+     * @var string  Current used file extension
+     */
+    protected $fileExtension = '.txt';
+
+    /**
+     * @inheritDoc
+     */
+    public function getName(): string
+    {
+        return 'TextExport';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function addHeader($filename)
+    {
+        $file = fopen($filename, 'w');
+        $bom = pack("CCC", 0xef, 0xbb, 0xbf);
+        fwrite($file, $bom);
+
+        $name = $this->getName();
+        if (isset($this->data[$name], $this->data[$name]['format'], $this->data[$name]['format'][0]) && in_array('addHeader', $this->data[$name]['format'])) {
+            $labeledCols = $this->getLabeledColumns();
+            $labels      = array();
+
+            if (in_array('formatVariable', $this->data[$name]['format'])) {
+                foreach($labeledCols as $columnName) {
+                    $labels[] = $this->metaModel->get($columnName, 'label');
+                }
+            } else {
+                $labels = $labeledCols;
+            }
+
+            if (isset($this->data[$name]) && isset($this->data[$name]['delimiter'])) {
+                $this->delimiter = $this->data[$name]['delimiter'];
+            }
+        } else {
+            $labels = array_keys($this->data);
+        }
+
+        fwrite($file, implode($this->delimiter, str_replace($this->delimiter, ' ', $labels)));
+        fclose($file);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function addRow($row, $file)
+    {
+        fwrite($file, implode($this->delimiter, str_replace($this->delimiter, ' ', $row)));
+    }
+
+    public function downloadFile(Iterator $iterator, DataExtractorInterface $extractor, string $exportId, string $fileName, array $exportSettings): array
+    {
+        $tempFileName = $this->tempExportDir . $exportId . '.' . static::EXTENSION;
+
+        $file = fopen($tempFileName, 'w');
+        $bom  = pack("CCC", 0xef, 0xbb, 0xbf);
+        fwrite($file, $bom);
+
+        $name = $this->getName();
+        // file_put_contents('data/logs/echo.txt', __CLASS__ . '->' . __FUNCTION__ . '(' . __LINE__ . '): ' .  print_r($exportSettings, true) . "\n", FILE_APPEND);
+
+        while ($row = $iterator->current()) {
+
+            $data = $extractor->extractData($row);
+
+            $this->writeRow($file, $data);
+
+            $iterator->next();
+        }
+
+        fclose($file);
+
+        return [$tempFileName => $fileName];
+    }
+
+    public function getDefaultFormValues(): array
+    {
+        return ['format'=> ['formatVariable' => 0, 'formatAnswer' => 0]];
+    }
+
+    public function getExportSettings(array $postData): array
+    {
+        $typeSettings = $this->getTypeExportSettings($postData);
+
+        return [
+            'translateHeaders' => isset($typeSettings['format']) && in_array('formatVariable', $typeSettings['format']),
+            'translateValues'  => isset($typeSettings['format']) && in_array('formatAnswer', $typeSettings['format']),
+       ];
+    }
+
+    public function getFormElements(Form &$form, array &$data, bool $multi = false): array
+    {
+        $elements = [];
+        $element = $form->createElement('multiCheckbox', 'format');
+        if ($element instanceof \Zend_Form_Element_MultiCheckbox) {
+            $element->setLabel($this->translator->_('Text options'));
+            $element->setMultiOptions([
+                'formatVariable' => $this->translator->_('Export labels instead of field names'),
+                'formatAnswer' => $this->translator->_('Format answers')
+            ]);
+            $element->setBelongsTo($this->getName());
+
+            $element->setSeparator('<br/>');
+            $elements['format'] = $element;
+        }
+
+        return $elements;
+    }
+
+    protected function writeRow($file, array $row)
+    {
+        fwrite($file, implode($this->delimiter, str_replace($this->delimiter, ' ', $row)) . "\r\n");
+    }
+}

--- a/src/Export/Type/TextExport.php
+++ b/src/Export/Type/TextExport.php
@@ -42,47 +42,6 @@ class TextExport extends ExportAbstract implements DownloadableInterface, Export
         return 'TextExport';
     }
 
-    /**
-     * @inheritDoc
-     */
-    protected function addHeader($filename)
-    {
-        $file = fopen($filename, 'w');
-        $bom = pack("CCC", 0xef, 0xbb, 0xbf);
-        fwrite($file, $bom);
-
-        $name = $this->getName();
-        if (isset($this->data[$name], $this->data[$name]['format'], $this->data[$name]['format'][0]) && in_array('addHeader', $this->data[$name]['format'])) {
-            $labeledCols = $this->getLabeledColumns();
-            $labels      = array();
-
-            if (in_array('formatVariable', $this->data[$name]['format'])) {
-                foreach($labeledCols as $columnName) {
-                    $labels[] = $this->metaModel->get($columnName, 'label');
-                }
-            } else {
-                $labels = $labeledCols;
-            }
-
-            if (isset($this->data[$name]) && isset($this->data[$name]['delimiter'])) {
-                $this->delimiter = $this->data[$name]['delimiter'];
-            }
-        } else {
-            $labels = array_keys($this->data);
-        }
-
-        fwrite($file, implode($this->delimiter, str_replace($this->delimiter, ' ', $labels)));
-        fclose($file);
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function addRow($row, $file)
-    {
-        fwrite($file, implode($this->delimiter, str_replace($this->delimiter, ' ', $row)));
-    }
-
     public function downloadFile(Iterator $iterator, DataExtractorInterface $extractor, string $exportId, string $fileName, array $exportSettings): array
     {
         $tempFileName = $this->tempExportDir . $exportId . '.' . static::EXTENSION;
@@ -91,11 +50,9 @@ class TextExport extends ExportAbstract implements DownloadableInterface, Export
         $bom  = pack("CCC", 0xef, 0xbb, 0xbf);
         fwrite($file, $bom);
 
-        $name = $this->getName();
         // file_put_contents('data/logs/echo.txt', __CLASS__ . '->' . __FUNCTION__ . '(' . __LINE__ . '): ' .  print_r($exportSettings, true) . "\n", FILE_APPEND);
 
         while ($row = $iterator->current()) {
-
             $data = $extractor->extractData($row);
 
             $this->writeRow($file, $data);

--- a/src/Handlers/ModelSnippetLegacyHandlerAbstract.php
+++ b/src/Handlers/ModelSnippetLegacyHandlerAbstract.php
@@ -371,7 +371,7 @@ abstract class ModelSnippetLegacyHandlerAbstract extends \MUtil\Handler\ModelSni
     public function exportAction()
     {
         $model  = $this->getExportModel();
-        $action = $this->responder->getSnippetsAction(ExportAction::class);
+        $action = $this->responder->getSnippetsAction($this->exportActionClass);
 
         if ($action instanceof ModelActionInterface) {
             $action->model = $model;
@@ -509,10 +509,11 @@ abstract class ModelSnippetLegacyHandlerAbstract extends \MUtil\Handler\ModelSni
      */
     protected function getExportModel(): DataReaderInterface
     {
-        $model = $this->getModel();
-        $noExportColumns = $model->getMetaModel()->getColNames('noExport');
+        $model           = $this->getModel();
+        $metaModel       = $model->getMetaModel();
+        $noExportColumns = $metaModel->getColNames('noExport');
         foreach($noExportColumns as $colName) {
-            $model->remove($colName, 'label');
+            $metaModel->remove($colName, 'label');
         }
         return $model;
     }

--- a/src/Handlers/TrackBuilder/SurveyMaintenanceHandler.php
+++ b/src/Handlers/TrackBuilder/SurveyMaintenanceHandler.php
@@ -18,6 +18,9 @@ use Gems\Locale\Locale;
 use Gems\Pdf;
 use Gems\Repository\SurveyRepository;
 use Gems\Snippets\Generic\CurrentButtonRowSnippet;
+use Gems\SnippetsActions\Browse\BrowseFilteredAction;
+use Gems\SnippetsActions\Export\ExportAction;
+use Gems\SnippetsActions\Export\ExportSurveySettingsAction;
 use Gems\Tracker;
 use Gems\Tracker\Model\SurveyMaintenanceModel;
 use Gems\Tracker\TrackEvent\SurveyBeforeAnsweringEventInterface;
@@ -30,6 +33,8 @@ use Zalt\Base\TranslatorInterface;
 use Zalt\Html\Html;
 use Zalt\Loader\ProjectOverloader;
 use Zalt\Model\Data\DataReaderInterface;
+use Zalt\SnippetsActions\Browse\BrowseTableAction;
+use Zalt\SnippetsActions\ModelActionInterface;
 use Zalt\SnippetsLoader\SnippetResponderInterface;
 
 /**
@@ -91,6 +96,8 @@ class SurveyMaintenanceHandler extends ModelSnippetLegacyHandlerAbstract
         'ModelFormSnippet',
         'Survey\\SurveyQuestionsSnippet'
     ];
+
+    protected string $exportSettingsActionClass = ExportSurveySettingsAction::class;
 
     /**
      * The snippets used for the index action, before those in autofilter
@@ -269,6 +276,17 @@ class SurveyMaintenanceHandler extends ModelSnippetLegacyHandlerAbstract
     {
         $this->surveyMaintenanceModel->applyStringAction($action, $detailed);
         return $this->surveyMaintenanceModel;
+    }
+
+    public function exportSettingsAction()
+    {
+        $this->exportActionClass = $this->exportSettingsActionClass;
+
+        $model  = $this->getExportModel();
+        $metaModel = $model->getMetaModel();
+        $metaModel->set('gsu_export_code', 'order', 1);
+
+        return $this->exportAction();
     }
 
     /**

--- a/src/Snippets/Export/ExportDownloadSnippet.php
+++ b/src/Snippets/Export/ExportDownloadSnippet.php
@@ -132,4 +132,9 @@ class ExportDownloadSnippet extends ModelTableSnippet
             $downloadLink,
         ];
     }
+
+    protected function getEditUrls(TableBridge $bridge, array $keys): array
+    {
+        return [];
+    }
 }

--- a/src/Snippets/Export/ExportFormSnippet.php
+++ b/src/Snippets/Export/ExportFormSnippet.php
@@ -7,7 +7,6 @@ use Gems\Export\Export;
 use Gems\Export\Type\ExportInterface;
 use Gems\Form;
 use Gems\Html;
-use Gems\Loader;
 use Gems\Menu\MenuSnippetHelper;
 use Gems\Snippets\FormSnippetAbstract;
 use Gems\SnippetsActions\Export\ExportAction;

--- a/src/Snippets/Tracker/Export/ExportSurveySettingsDownloadStepSnippet.php
+++ b/src/Snippets/Tracker/Export/ExportSurveySettingsDownloadStepSnippet.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @package    Gems
+ * @subpackage Snippets\Tracker\Export
+ * @author     Matijs de Jong <mjong@magnafacta.nl>
+ */
+
+namespace Gems\Snippets\Tracker\Export;
+
+use Gems\Export\Db\DbExportRepository;
+use Gems\Export\Db\FileExportDownloadModel;
+use Gems\Legacy\CurrentUserRepository;
+use Gems\Menu\MenuSnippetHelper;
+use Gems\Snippets\Export\ExportDownloadStepSnippet;
+use Gems\SnippetsActions\Export\ExportAction;
+use Gems\Tracker\Export\ExportSurveySettings;
+use Zalt\Base\RequestInfo;
+use Zalt\Base\TranslatorInterface;
+use Zalt\SnippetsLoader\SnippetOptions;
+
+/**
+ * @package    Gems
+ * @subpackage Snippets\Tracker\Export
+ * @since      Class available since version 1.0
+ */
+class ExportSurveySettingsDownloadStepSnippet extends ExportDownloadStepSnippet
+{
+    public function __construct(
+        SnippetOptions $snippetOptions,
+        RequestInfo $requestInfo,
+        MenuSnippetHelper $menuHelper,
+        TranslatorInterface $translate,
+        FileExportDownloadModel $fileExportDownloadModel,
+        DbExportRepository $dbExportRepository,
+        ExportSurveySettings $export,
+        CurrentUserRepository $currentUserRepository,
+        ExportAction $exportAction)
+    {
+        parent::__construct($snippetOptions, $requestInfo, $menuHelper, $translate, $fileExportDownloadModel, $dbExportRepository, $export, $currentUserRepository, $exportAction);
+    }
+
+}

--- a/src/Snippets/Tracker/Export/ExportSurveySettingsSnippet.php
+++ b/src/Snippets/Tracker/Export/ExportSurveySettingsSnippet.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @package    Gems
+ * @subpackage Snippets\Tracker\Export
+ * @author     Matijs de Jong <mjong@magnafacta.nl>
+ */
+
+namespace Gems\Snippets\Tracker\Export;
+
+use Gems\Audit\AuditLog;
+use Gems\Export\Export;
+use Gems\Menu\MenuSnippetHelper;
+use Gems\Snippets\Export\ExportFormSnippet;
+use Gems\SnippetsActions\Export\ExportSurveySettingsAction;
+use Gems\Tracker\Export\ExportSurveySettings;
+use Mezzio\Session\SessionInterface;
+use Zalt\Base\RequestInfo;
+use Zalt\Base\TranslatorInterface;
+use Zalt\Loader\ProjectOverloader;
+use Zalt\Message\MessengerInterface;
+use Zalt\SnippetsLoader\SnippetOptions;
+
+/**
+ * @package    Gems
+ * @subpackage Snippets\Tracker\Export
+ * @since      Class available since version 1.0
+ */
+class ExportSurveySettingsSnippet extends ExportFormSnippet
+{
+    public function __construct(
+        SnippetOptions $snippetOptions,
+        RequestInfo $requestInfo,
+        TranslatorInterface $translate,
+        MessengerInterface $messenger,
+        AuditLog $auditLog,
+        MenuSnippetHelper $menuHelper,
+        ExportSurveySettingsAction $exportAction,
+        SessionInterface $session,
+        ProjectOverloader $overLoader,
+        ExportSurveySettings $export,
+    ) {
+        parent::__construct($snippetOptions, $requestInfo, $translate, $messenger, $auditLog, $menuHelper, $exportAction, $session, $overLoader, $export);
+    }
+}

--- a/src/SnippetsActions/Export/ExportSurveySettingsAction.php
+++ b/src/SnippetsActions/Export/ExportSurveySettingsAction.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @package    Gems
+ * @subpackage SnippetsActions\Export
+ * @author     Matijs de Jong <mjong@magnafacta.nl>
+ */
+
+namespace Gems\SnippetsActions\Export;
+
+use Gems\Snippets\Export\ExportBatchSnippet;
+use Gems\Snippets\Tracker\Export\ExportSurveySettingsDownloadStepSnippet;
+use Gems\Snippets\Tracker\Export\ExportSurveySettingsSnippet;
+
+/**
+ * @package    Gems
+ * @subpackage SnippetsActions\Export
+ * @since      Class available since version 1.0
+ */
+class ExportSurveySettingsAction extends ExportAction
+{
+    /**
+     * @var array Of snippet class names
+     */
+    protected array $_snippets = [
+        ExportSurveySettingsSnippet::class,
+        ExportBatchSnippet::class,
+        ExportSurveySettingsDownloadStepSnippet::class,
+    ];
+
+    public function isDetailed() : bool
+    {
+        return true;
+    }
+}

--- a/src/Tracker/Export/ExportSurveySettings.php
+++ b/src/Tracker/Export/ExportSurveySettings.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @package    Gems
+ * @subpackage Tracker\Export
+ * @author     Matijs de Jong <mjong@magnafacta.nl>
+ */
+
+namespace Gems\Tracker\Export;
+
+use Gems\Export\Export;
+
+/**
+ * @package    Gems
+ * @subpackage Tracker\Export
+ * @since      Class available since version 1.0
+ */
+class ExportSurveySettings extends Export
+{
+    /**
+     * This variable holds all registered export classes, may be changed in derived classes
+     *
+     * @var array Of classname => description
+     */
+    protected array $exportClasses =  [
+        'TextExport' => 'Text',
+    ];
+
+    protected array $streamingExportClasses = [
+    ];
+
+    /**
+     * Returns all registered export classes
+     *
+     * @return string[] Array Of classname => description
+     */
+    public function getExportClasses(bool $sensitiveData = true): array
+    {
+        return $this->exportClasses;
+    }
+
+    public function streamOnly(bool $sensitiveData = true): bool
+    {
+        return false;
+    }
+}

--- a/src/Tracker/Model/SurveyMaintenanceModel.php
+++ b/src/Tracker/Model/SurveyMaintenanceModel.php
@@ -121,6 +121,7 @@ class SurveyMaintenanceModel extends GemsJoinModel implements ApplyLegacyActionI
             $this->metaModel->set('track_usage', [
                 'label' => $this->_('Usage'),
                 'elementClass' => 'Exhibitor',
+                'noExport' => true,
                 'noSort' => true,
                 'no_text_search' => true,
             ]);
@@ -129,9 +130,10 @@ class SurveyMaintenanceModel extends GemsJoinModel implements ApplyLegacyActionI
             $this->metaModel->set('calc_duration', [
                 'label' => $this->_('Duration calculated'),
                 'elementClass' => 'Html',
+                'noExport' => true,
                 'noSort' => true,
                 'no_text_search' => true,
-            ]);
+                ]);
             $this->metaModel->setOnLoad('calc_duration', [$this, 'calculateDuration']);
 
             $this->metaModel->set('gsu_duration', [
@@ -266,27 +268,35 @@ class SurveyMaintenanceModel extends GemsJoinModel implements ApplyLegacyActionI
             'label' => $this->_('Available languages'),
             'elementClass' => 'Exhibitor',
             'itemDisplay' => [$this, 'formatLanguages'],
+            'noExport' => true,
         ]);
 
         $this->metaModel->set('gso_source_name', [
             'label' => $this->_('Source'),
             'elementClass' => 'Exhibitor',
+            'noExport' => true,
         ]);
         $this->metaModel->set('gsu_surveyor_active', [
             'label' => $this->_('Active in source'),
             'elementClass' => 'Exhibitor',
             'multiOptions' => $yesNo,
+            'noExport' => true,
         ]);
-        $this->metaModel->set('gsu_surveyor_id',    'label', $this->_('Source survey id'),
-                'elementClass', 'Exhibitor'
-                );
-        $this->metaModel->set('gsu_status_show',        'label', $this->_('Status in source'),
-                'elementClass', 'Exhibitor'
-                );
-        $this->metaModel->set('gsu_survey_warnings',        'label', $this->_('Warnings'),
-                'elementClass', 'Exhibitor',
-                'formatFunction', [$this, 'formatWarnings']
-                );
+        $this->metaModel->set('gsu_surveyor_id', [
+            'label' => $this->_('Source survey id'),
+            'elementClass' =>  'Exhibitor'
+            ]);
+        $this->metaModel->set('gsu_status_show', [
+            'label' => $this->_('Status in source'),
+            'elementClass' => 'Exhibitor',
+            'noExport' => true,
+            ]);
+        $this->metaModel->set('gsu_survey_warnings', [
+            'label' => $this->_('Warnings'),
+            'elementClass' => 'Exhibitor',
+            'formatFunction' => [$this, 'formatWarnings'],
+            'noExport' => true,
+            ]);
 
         $this->metaModel->set('gsu_active', [
             'label' => sprintf($this->_('Active in %s'), $this->configAccessor->getAppName()),
@@ -359,6 +369,7 @@ class SurveyMaintenanceModel extends GemsJoinModel implements ApplyLegacyActionI
             'description' => $this->_('The organizations where the survey may be inserted.'),
             'elementClass' => 'MultiCheckbox',
             'multiOptions' => $this->organizationRepository->getOrganizationsWithRespondents(),
+            'noExport' => true,
             'required' => true,
             'type' => new ConcatenatedType('|', $this->_(', ')),
         ]);

--- a/src/Tracker/SurveyModel.php
+++ b/src/Tracker/SurveyModel.php
@@ -14,7 +14,6 @@ use Zalt\String\Str;
 
 class SurveyModel extends GemsJoinModel
 {
-
     /**
      * Constant containing css classname for main questions
      */


### PR DESCRIPTION
This functionality was left out of GT 2, but is needed to import the settings from CP to Rijndam in version 1.9