### PR TITLE
fix token_url_input

### DIFF
--- a/src/Mail/TokenMailFields.php
+++ b/src/Mail/TokenMailFields.php
@@ -55,7 +55,7 @@ class TokenMailFields extends RespondentMailFields
             'token_until' => $this->token->getValidUntil() instanceof \DateTimeInterface ? $this->token->getValidUntil()->format('Y-m-d') : null,
             'token_url' => $tokenLink,
             'token_direct_url' => $tokenToSurveyLink,
-            'token_url_input' => $askUrl . 'index/' . $this->token->getTokenId(),
+            'token_url_input' => $askUrl . '/?id=' . $this->token->getTokenId(),
             'track' => $this->token->getTrackName(),
         ];
 


### PR DESCRIPTION
token_url_input url did not work! (link would be /askindex/<token-id> ). This fixes the link, although the token parameter is not used in the actual snippet to prefill the input field. This should be fixed separately